### PR TITLE
Farabi/remove-account-switcher-and-logic-for-single-account-use

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/account-info.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info.jsx
@@ -1,32 +1,20 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { CSSTransition } from 'react-transition-group';
-import { Icon, Text } from '@deriv/components';
+import { Text } from '@deriv/components';
 import { Localize, localize } from '@deriv/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { useDevice } from '@deriv-com/ui';
-import AccountSwitcher from 'App/Containers/AccountSwitcher';
-import AccountSwitcherMobile from 'App/Containers/AccountSwitcher/account-switcher-mobile';
 import AccountInfoWrapper from './account-info-wrapper';
 import AccountInfoIcon from './account-info-icon';
 
-const AccountInfo = ({
-    acc_switcher_disabled_message,
-    balance,
-    currency,
-    disableApp,
-    enableApp,
-    is_dialog_on,
-    is_virtual,
-    toggleDialog,
-    is_disabled,
-    is_mobile,
-}) => {
+const AccountInfo = ({ acc_switcher_disabled_message, balance, currency, is_virtual, is_disabled, is_mobile }) => {
     const currency_lower = currency?.toLowerCase();
     const { isDesktop } = useDevice();
 
     return (
         <div className='acc-info__wrapper'>
+            {isDesktop && <div className='acc-info__separator' />}
             <AccountInfoWrapper
                 is_disabled={is_disabled}
                 disabled_message={acc_switcher_disabled_message}
@@ -36,11 +24,9 @@ const AccountInfo = ({
                     data-testid='dt_acc_info'
                     id='dt_core_account-info_acc-info'
                     className={classNames('acc-info', {
-                        'acc-info--show': is_dialog_on,
                         'acc-info--is-virtual': is_virtual,
                         'acc-info--is-disabled': is_disabled,
                     })}
-                    onClick={is_disabled ? undefined : () => toggleDialog()}
                 >
                     <span className='acc-info__id'>
                         {isDesktop ? (
@@ -56,21 +42,6 @@ const AccountInfo = ({
                             <Text as='p' size='xxs' className='acc-info__account-type'>
                                 {is_virtual ? localize('Demo') : localize('Real')}
                             </Text>
-                            {is_disabled ? (
-                                <Icon
-                                    data_testid='dt_lock_icon'
-                                    icon='IcLock'
-                                    className='acc-info__select-arrow'
-                                    size={12}
-                                />
-                            ) : (
-                                <Icon
-                                    data_testid='dt_select_arrow'
-                                    icon='IcChevronDownBold'
-                                    className='acc-info__select-arrow'
-                                    size={12}
-                                />
-                            )}
                         </div>
                         {(typeof balance !== 'undefined' || !currency) && (
                             <div className='acc-info__balance-section'>
@@ -91,30 +62,6 @@ const AccountInfo = ({
                     </div>
                 </div>
             </AccountInfoWrapper>
-            <div className='acc-info__separator' />
-            {isDesktop ? (
-                <CSSTransition
-                    in={is_dialog_on}
-                    timeout={200}
-                    classNames={{
-                        enter: 'acc-switcher__wrapper--enter',
-                        enterDone: 'acc-switcher__wrapper--enter-done',
-                        exit: 'acc-switcher__wrapper--exit',
-                    }}
-                    unmountOnExit
-                >
-                    <div className='acc-switcher__wrapper'>
-                        <AccountSwitcher is_visible={is_dialog_on} toggle={toggleDialog} />
-                    </div>
-                </CSSTransition>
-            ) : (
-                <AccountSwitcherMobile
-                    is_visible={is_dialog_on}
-                    disableApp={disableApp}
-                    enableApp={enableApp}
-                    toggle={toggleDialog}
-                />
-            )}
         </div>
     );
 };
@@ -123,14 +70,10 @@ AccountInfo.propTypes = {
     acc_switcher_disabled_message: PropTypes.string,
     balance: PropTypes.string,
     currency: PropTypes.string,
-    disableApp: PropTypes.func,
-    enableApp: PropTypes.func,
-    is_dialog_on: PropTypes.bool,
     is_disabled: PropTypes.bool,
     is_virtual: PropTypes.bool,
     is_mobile: PropTypes.bool,
     loginid: PropTypes.string,
-    toggleDialog: PropTypes.func,
 };
 
 export default AccountInfo;

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -75,17 +75,16 @@ const BinarySocketGeneral = (() => {
                     }
                     client_store.logout();
                 } else if (!/authorize/.test(State.get('skip_response'))) {
-                    // is_populating_account_list is a check to avoid logout on the first logged-in session
-                    // In any other case, if the response loginid does not match the store's loginid, user must be logged out
-                    if (
-                        response.authorize.loginid !== client_store.loginid &&
-                        !client_store.is_populating_account_list &&
-                        !client_store.is_switching
-                    ) {
-                        client_store.logout();
-                    } else if (response.authorize.loginid === client_store.loginid) {
-                        // All other cases continue with the loginid and authorize the profile
+                    // Simplified authorization for single account model
+                    if (response.authorize.loginid === client_store.loginid) {
                         authorizeAccount(response);
+                    } else if (client_store.is_populating_account_list) {
+                        // During initial login, allow loginid mismatch and update the store
+                        client_store.setLoginId(response.authorize.loginid);
+                        authorizeAccount(response);
+                    } else {
+                        // Only logout if it's not during initial account population
+                        client_store.logout();
                     }
                 }
                 break;

--- a/packages/core/src/Stores/common-store.js
+++ b/packages/core/src/Stores/common-store.js
@@ -207,14 +207,9 @@ export default class CommonStore extends BaseStore {
     setIsSocketOpened(is_socket_opened) {
         // note that it's not for account switch that we're doing this,
         // but rather to reset account related stores like portfolio and contract-trade
-        const should_broadcast_account_change = this.was_socket_opened && is_socket_opened;
 
         this.is_socket_opened = is_socket_opened;
         this.was_socket_opened = this.was_socket_opened || is_socket_opened;
-
-        if (should_broadcast_account_change) {
-            this.root_store.client.broadcastAccountChangeAfterAuthorize();
-        }
     }
 
     setNetworkStatus(status, is_online) {

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -29,8 +29,6 @@ export default class UIStore extends BaseStore {
     is_settings_modal_on = false;
     is_language_settings_modal_on = false;
     is_mobile_language_menu_open = false;
-    is_accounts_switcher_on = false;
-    account_switcher_disabled_message = '';
 
     has_only_forward_starting_contracts = false;
 
@@ -195,7 +193,6 @@ export default class UIStore extends BaseStore {
 
         makeObservable(this, {
             account_needed_modal_props: observable,
-            account_switcher_disabled_message: observable,
             has_only_forward_starting_contracts: observable,
             is_services_error_visible: observable,
             is_link_expired_modal_visible: observable,
@@ -228,8 +225,6 @@ export default class UIStore extends BaseStore {
             is_account_needed_modal_on: observable,
             is_forced_to_exit_pnv: observable,
             is_phone_verification_completed: observable,
-
-            is_accounts_switcher_on: observable,
 
             is_app_disabled: observable,
             is_cfd_page: observable,
@@ -295,7 +290,6 @@ export default class UIStore extends BaseStore {
             handleResize: action.bound,
             init: action.bound,
             installWithDeferredPrompt: action.bound,
-            is_account_switcher_disabled: computed,
             is_desktop: computed,
             is_mobile: computed,
             is_tablet: computed,
@@ -317,7 +311,6 @@ export default class UIStore extends BaseStore {
             resetRealAccountSignupParams: action.bound,
             resetRealAccountSignupTarget: action.bound,
             setShouldShowPhoneNumberOTP: action.bound,
-            setAccountSwitcherDisabledMessage: action.bound,
             setAppContentsScrollRef: action.bound,
             setChartCountdown: action.bound,
             setChartLayout: action.bound,
@@ -354,7 +347,6 @@ export default class UIStore extends BaseStore {
             setIsMFVericationPendingModal: action.bound,
             setIsTradingDisabledByResidenceModal: action.bound,
             setMobileLanguageMenuOpen: action.bound,
-            toggleAccountsDialog: action.bound,
             toggleCancellationWarning: action.bound,
             toggleHistoryTab: action.bound,
             toggleOnScreenKeyboard: action.bound,
@@ -465,10 +457,6 @@ export default class UIStore extends BaseStore {
         return MAX_MOBILE_WIDTH < this.screen_width && this.screen_width <= MAX_TABLET_WIDTH;
     }
 
-    get is_account_switcher_disabled() {
-        return !!this.account_switcher_disabled_message;
-    }
-
     setRouteModal() {
         this.is_route_modal_on = true;
     }
@@ -483,19 +471,6 @@ export default class UIStore extends BaseStore {
 
     enableApp() {
         this.is_app_disabled = false;
-    }
-
-    toggleAccountsDialog(status = !this.is_accounts_switcher_on) {
-        this.is_accounts_switcher_on = status;
-    }
-
-    setAccountSwitcherDisabledMessage(message) {
-        if (message) {
-            this.is_accounts_switcher_on = false;
-            this.account_switcher_disabled_message = message;
-        } else {
-            this.account_switcher_disabled_message = '';
-        }
     }
 
     setIsFromSignupAccount(is_from_signup_account) {
@@ -596,7 +571,6 @@ export default class UIStore extends BaseStore {
                 this.is_real_acc_signup_on = true;
             }
             this.real_account_signup_target = target;
-            this.is_accounts_switcher_on = false;
             localStorage.removeItem('current_question_index');
         }
     }

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -43,7 +43,6 @@
         display: flex;
         align-items: center;
         -webkit-box-align: center;
-        padding-right: 0.8rem;
         gap: 1.6rem;
 
         @include mobile-screen {


### PR DESCRIPTION
This pull request simplifies the codebase by removing support for account switching and transitioning to a single-account model. It also includes cleanup of related UI components and logic. The most important changes are grouped into the following themes:

### Removal of Account Switching Logic:
* Removed account switching methods, properties, and related logic from the `ClientStore` class, including `switchAccount`, `switchAccountHandler`, and `broadcastAccountChange`. This simplifies account management for the single-account model.
* Updated the `BinarySocketGeneral` logic to handle authorization for a single account model, removing checks and actions related to account switching. (`[packages/core/src/Services/socket-general.jsL78-R87]

### UI Component Simplifications:
* Refactored the `AccountInfo` component to remove account switcher-related UI elements and properties, such as `is_dialog_on` and `toggleDialog`. This includes removing associated icons and components like `AccountSwitcher` and `AccountSwitcherMobile`.
* Removed `is_accounts_switcher_on` and `account_switcher_disabled_message` properties from the `UIStore`. (`[packages/core/src/Stores/ui-store.jsL32-L33]

### Code Cleanup:
* Removed obsolete properties and actions from `ClientStore`, such as `is_switching`, `pre_switch_broadcast`, and `switch_broadcast`.
* Deleted unused methods and reactions related to account switching, such as `registerReactions` and `broadcastAccountChangeAfterAuthorize`.

These changes streamline the codebase, reduce complexity, and align the application with the new single-account model.