### PR TITLE
Farabi/remove-one-time-token-from-url

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1815,6 +1815,9 @@ export default class ClientStore extends BaseStore {
 
                 sessionToken = sessionResponse.get_session_token.token;
                 this.storeSessionToken(sessionToken);
+
+                // Remove the one-time token from URL after successful exchange
+                this.removeTokenFromUrl();
             } else if (!sessionToken) {
                 return {
                     error: {
@@ -1886,6 +1889,14 @@ export default class ClientStore extends BaseStore {
 
     clearSessionToken() {
         localStorage.removeItem('session_token');
+    }
+
+    removeTokenFromUrl() {
+        const url = new URL(window.location.href);
+        if (url.searchParams.has('token')) {
+            url.searchParams.delete('token');
+            window.history.replaceState({}, document.title, url.toString());
+        }
     }
 
     async canStoreClientAccounts(obj_params, account_list) {


### PR DESCRIPTION
This pull request introduces an improvement to the authentication flow in the `ClientStore` by ensuring that one-time tokens are removed from the URL after they have been successfully exchanged. This helps prevent potential security issues and keeps the URL clean for users. The main changes are:

Authentication flow improvements:

* Added a new `removeTokenFromUrl` method to `ClientStore` that removes the `token` query parameter from the URL after a successful token exchange.
* Updated the session token exchange logic to call `removeTokenFromUrl` after storing the session token.