### PR TITLE
chore: update @deriv-com/derivatives-charts to v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
                 "@babel/preset-typescript": "^7.24.7",
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.0.3",
+                "@deriv-com/derivatives-charts": "^1.0.4",
                 "@types/react-transition-group": "^4.4.4",
                 "babel-jest": "^29.7.0",
                 "dotenv": "^8.2.0",
@@ -2189,7 +2189,9 @@
             }
         },
         "node_modules/@deriv-com/derivatives-charts": {
-            "version": "1.0.3",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.0.4.tgz",
+            "integrity": "sha512-fYqaRYnkNFXQYpphKaBEJaxwoK/OPsBkC2sjnGEK2p//CdfBjwLJu76kk207wewJ0L9+xFc9fWODmgaTlhsZ9w==",
             "license": "ISC",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
@@ -32574,7 +32576,7 @@
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "1.31.3",
                 "@deriv-com/auth-client": "1.5.2",
-                "@deriv-com/derivatives-charts": "^1.0.3",
+                "@deriv-com/derivatives-charts": "^1.0.4",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/translations": "1.3.9",
@@ -32862,7 +32864,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.0.3",
+                "@deriv-com/derivatives-charts": "^1.0.4",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/ui": "1.36.4",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/preset-typescript": "^7.24.7",
         "@deriv-com/analytics": "1.31.3",
-        "@deriv-com/derivatives-charts": "^1.0.3",
+        "@deriv-com/derivatives-charts": "^1.0.4",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^29.7.0",
         "dotenv": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,7 +103,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.0.3",
+        "@deriv-com/derivatives-charts": "^1.0.4",
         "@deriv/quill-icons": "2.2.1",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -93,7 +93,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.0.3",
+        "@deriv-com/derivatives-charts": "^1.0.4",
         "@deriv/api": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
## Changes:
This pull request updates the `@deriv-com/derivatives-charts` dependency from version `1.0.3` to `1.0.4` across multiple packages to ensure consistency and benefit from any fixes or improvements in the newer version.

Dependency updates:

* Updated `@deriv-com/derivatives-charts` to version `^1.0.4` in the root `package.json` file.
* Updated `@deriv-com/derivatives-charts` to version `^1.0.4` in `packages/core/package.json`.
* Updated `@deriv-com/derivatives-charts` to version `^1.0.4` in `packages/trader/package.json`.
