### PR TITLE
Farabi/remove-invalid-token-from-url

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1800,6 +1800,9 @@ export default class ClientStore extends BaseStore {
 
             // If we don't have a session token but we have a one-time token, exchange it
             if (!sessionToken && oneTimeToken) {
+                // Remove the one-time token from URL immediately
+                this.removeTokenFromUrl();
+
                 const sessionResponse = await WS.getSessionToken(oneTimeToken);
 
                 if (sessionResponse.error) {
@@ -1813,9 +1816,6 @@ export default class ClientStore extends BaseStore {
 
                 sessionToken = sessionResponse.get_session_token.token;
                 this.storeSessionToken(sessionToken);
-
-                // Remove the one-time token from URL after successful exchange
-                this.removeTokenFromUrl();
             } else if (!sessionToken) {
                 return {
                     error: {


### PR DESCRIPTION
This pull request updates the handling of one-time tokens in the `ClientStore` class to improve user experience during token exchange. The main change is to remove the one-time token from the URL immediately, rather than waiting until after a successful exchange.

Session token exchange flow improvements:

* The call to `removeTokenFromUrl()` was moved to execute immediately when a one-time token is detected, ensuring the token is cleared from the URL before the exchange process begins.
* The previous logic that removed the one-time token from the URL after a successful exchange was removed, as it is now handled earlier in the flow.