### PR TITLE
Farabi/grwt-6913/fix-signup-redirection

### DIFF
--- a/packages/api/src/hooks/useOauth2.ts
+++ b/packages/api/src/hooks/useOauth2.ts
@@ -19,7 +19,7 @@ import useTMB from './useTMB';
  */
 const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
     const is_deriv_com = /deriv\.(com)/.test(window.location.hostname) || /localhost:8443/.test(window.location.host);
-    const { common, client } = useStore();
+    const { common } = useStore();
     const { isTmbEnabled } = useTMB();
 
     const loginHandler = async () => {
@@ -38,7 +38,7 @@ const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
                 console.error(err);
             }
         } else {
-            redirectToLogin(false, getLanguage());
+            redirectToLogin();
         }
     };
 

--- a/packages/components/src/components/route-with-subroutes/route-with-subroutes.tsx
+++ b/packages/components/src/components/route-with-subroutes/route-with-subroutes.tsx
@@ -29,7 +29,6 @@ const RouteWithSubRoutes = ({
     path,
     routes,
     to,
-    language,
     Component404,
     should_redirect_login,
 }: TRoutesWithSubRoutesProps) => {
@@ -60,7 +59,7 @@ const RouteWithSubRoutes = ({
             result = <Redirect to={redirect_to} />;
         } else if (is_authenticated && !is_logged_in && !is_logging_in) {
             if (should_redirect_login) {
-                redirectToLogin(is_logged_in, language);
+                redirectToLogin();
             } else {
                 result = <Redirect to={shared_routes.index} />;
             }

--- a/packages/core/src/App/Components/Layout/Header/login-button.jsx
+++ b/packages/core/src/App/Components/Layout/Header/login-button.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Button } from '@deriv/components';
 import { useTMB } from '@deriv/api';
 import { getDomainUrl, isStaging, redirectToLogin } from '@deriv/shared';
-import { getLanguage, localize } from '@deriv/translations';
+import { localize } from '@deriv/translations';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
 
 const LoginButton = ({ className }) => {
@@ -42,7 +42,7 @@ const LoginButton = ({ className }) => {
                     }
                 }
                 window.LiveChatWidget?.call('hide');
-                redirectToLogin(false, getLanguage());
+                redirectToLogin();
             }}
             tertiary
         />

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -184,17 +184,19 @@ const ToggleMenuDrawer = observer(() => {
                     <div className='header__menu-mobile-body-wrapper'>
                         <React.Fragment>
                             <MobileDrawer.Body>
-                                <MobileDrawer.Item>
-                                    <MenuLink
-                                        link_to={getBrandHubHomeUrl()}
-                                        icon='IcAppstoreTradersHubHome'
-                                        text={localize('Hub')}
-                                        onClickLink={() => {
-                                            window.open(getBrandHubHomeUrl(), '_blank', 'noopener,noreferrer');
-                                            toggleDrawer();
-                                        }}
-                                    />
-                                </MobileDrawer.Item>
+                                {is_logged_in && (
+                                    <MobileDrawer.Item>
+                                        <MenuLink
+                                            link_to={getBrandHubHomeUrl()}
+                                            icon='IcAppstoreTradersHubHome'
+                                            text={localize('Hub')}
+                                            onClickLink={() => {
+                                                window.open(getBrandHubHomeUrl(), '_blank', 'noopener,noreferrer');
+                                                toggleDrawer();
+                                            }}
+                                        />
+                                    </MobileDrawer.Item>
+                                )}
                                 <MobileDrawer.Item>
                                     <MenuLink
                                         link_to={routes.index}

--- a/packages/core/src/App/Containers/Layout/app-contents.jsx
+++ b/packages/core/src/App/Containers/Layout/app-contents.jsx
@@ -3,11 +3,10 @@ import { useLocation, withRouter } from 'react-router';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import { ThemedScrollbars } from '@deriv/components';
 import { useGrowthbookGetFeatureValue } from '@deriv/api';
+import { ThemedScrollbars } from '@deriv/components';
 import { CookieStorage, platforms, redirectToLogin, TRACKING_STATUS_KEY, WS } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { getLanguage } from '@deriv/translations';
 import { Analytics } from '@deriv-com/analytics';
 import { useDevice } from '@deriv-com/ui';
 
@@ -59,7 +58,7 @@ const AppContents = observer(({ children }) => {
                 setShouldRedirectToLogin(false);
             } else {
                 setShouldRedirectToLogin(false);
-                redirectToLogin(is_logged_in, getLanguage());
+                redirectToLogin();
             }
         }
     }, [should_redirect_user_to_login, is_logged_in, setShouldRedirectToLogin, client.is_client_store_initialized]);

--- a/packages/core/src/App/Containers/Redirect/redirect.jsx
+++ b/packages/core/src/App/Containers/Redirect/redirect.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 import { getBrandHubUrl, getDomainName, redirectToLogin, routes, SessionStore } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { getLanguage } from '@deriv/translations';
 import { Chat } from '@deriv/utils';
 import { Analytics } from '@deriv-com/analytics';
 
@@ -114,7 +113,7 @@ const Redirect = observer(() => {
                 if (verification_code[action_param]) {
                     sessionStorage.setItem('request_email_code', verification_code[action_param]);
                 }
-                redirectToLogin(is_logged_in, getLanguage(), true);
+                redirectToLogin();
                 redirected_to_route = true;
             } else {
                 if (!verification_code[action_param]) {
@@ -144,7 +143,7 @@ const Redirect = observer(() => {
                 if (verification_code[action_param]) {
                     sessionStorage.setItem(reset_code_key, verification_code[action_param]);
                 }
-                redirectToLogin(is_logged_in, getLanguage());
+                redirectToLogin();
                 redirected_to_route = true;
                 break;
             }

--- a/packages/core/src/App/Containers/RedirectToLoginModal/redirect-to-login-modal.jsx
+++ b/packages/core/src/App/Containers/RedirectToLoginModal/redirect-to-login-modal.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+
 import { Dialog, Text } from '@deriv/components';
-import { Localize, getLanguage } from '@deriv/translations';
 import { redirectToLogin } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
+import { Localize } from '@deriv/translations';
 
 const ModalHeader = ({ header }) => {
     switch (header) {
@@ -29,7 +30,7 @@ const RedirectToLoginModal = observer(() => {
     const showModal = () => {
         setVisible(true);
         if (window.localStorage.getItem('is_redirecting') !== 'true') {
-            redirectToLogin(false, getLanguage(), false, 3000);
+            redirectToLogin();
         }
     };
 

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -395,7 +395,7 @@ export default class ClientStore extends BaseStore {
                 should_show_refresh: false,
                 redirect_label: localize('Log in'),
                 redirectOnClick: () => {
-                    redirectToLogin(false, getLanguage());
+                    redirectToLogin();
                 },
             });
             this.setIsLoggingIn(false);

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+
 import { Button, Modal } from '@deriv/components';
-import { getLanguage, localize } from '@deriv/translations';
 import { redirectToLogin, redirectToSignUp } from '@deriv/shared';
+import { localize } from '@deriv/translations';
 
 type TAuthorizationRequiredModal = {
     is_visible: boolean;
@@ -10,12 +11,7 @@ type TAuthorizationRequiredModal = {
     is_logged_in: boolean;
 };
 
-const AuthorizationRequiredModal = ({
-    is_visible,
-    toggleModal,
-    is_appstore,
-    is_logged_in,
-}: TAuthorizationRequiredModal) => (
+const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => (
     <Modal
         id='dt_authorization_required_modal'
         is_open={is_visible}
@@ -25,18 +21,8 @@ const AuthorizationRequiredModal = ({
     >
         <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
         <Modal.Footer>
-            <Button
-                has_effect
-                text={localize('Log in')}
-                onClick={() => redirectToLogin(is_logged_in, getLanguage())}
-                secondary
-            />
-            <Button
-                has_effect
-                text={localize('Create free account')}
-                onClick={() => redirectToSignUp({ is_appstore })}
-                primary
-            />
+            <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
+            <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
         </Modal.Footer>
     </Modal>
 );

--- a/packages/shared/src/utils/brand/brand.ts
+++ b/packages/shared/src/utils/brand/brand.ts
@@ -50,3 +50,7 @@ export const getBrandHubHomeUrl = () => {
 export const getBrandHubLoginUrl = () => {
     return `${getBrandHubUrl()}/login`;
 };
+
+export const getBrandHubSignupUrl = () => {
+    return `${getBrandHubUrl()}/signup`;
+};

--- a/packages/shared/src/utils/helpers/active-symbols.ts
+++ b/packages/shared/src/utils/helpers/active-symbols.ts
@@ -3,7 +3,7 @@ import { LocalStore } from '../storage';
 import { redirectToLogin } from '../login';
 import { WS } from '../../services';
 
-import { getLanguage, localize } from '@deriv/translations';
+import { localize } from '@deriv/translations';
 import { ActiveSymbols } from '@deriv/api-types';
 import { getMarketNamesMap } from '../constants/contract';
 
@@ -22,7 +22,7 @@ type TIsSymbolOpen = {
     exchange_is_open: 0 | 1;
 };
 
-export const showUnavailableLocationError = flow(function* (showError, is_logged_in) {
+export const showUnavailableLocationError = flow(function* (showError) {
     const website_status = yield WS.wait('website_status');
     const residence_list: TResidenceList = yield WS.residenceList();
 
@@ -39,7 +39,7 @@ export const showUnavailableLocationError = flow(function* (showError, is_logged
         message: localize('If you have an account, log in to continue.'),
         header,
         redirect_label: localize('Log in'),
-        redirectOnClick: () => redirectToLogin(is_logged_in, getLanguage()),
+        redirectOnClick: () => redirectToLogin(),
         should_show_refresh: false,
     });
 });

--- a/packages/shared/src/utils/login/login.ts
+++ b/packages/shared/src/utils/login/login.ts
@@ -1,36 +1,9 @@
-import { isStorageSupported } from '../storage/storage';
-import { getHubSignupUrl } from '../url';
-import { routes } from '../routes/routes';
-import { getBrandHubLoginUrl } from '../brand';
+import { getBrandHubLoginUrl, getBrandHubSignupUrl } from '../brand';
 
-export const redirectToLogin = (is_logged_in: boolean, language: string, has_params = true, redirect_delay = 0) => {
-    if (!is_logged_in && isStorageSupported(sessionStorage)) {
-        const l = window.location;
-        const redirect_url = has_params ? window.location.href : `${l.protocol}//${l.host}${l.pathname}`;
-        sessionStorage.setItem('redirect_url', redirect_url);
-        setTimeout(() => {
-            // Use external login instead of OAuth
-            window.location.href = getBrandHubLoginUrl();
-        }, redirect_delay);
-    }
+export const redirectToLogin = () => {
+    window.location.href = getBrandHubLoginUrl();
 };
 
 export const redirectToSignUp = () => {
-    const location = window.location.href;
-    const isDtraderRoute = window.location.pathname.includes(routes.index);
-
-    if (isDtraderRoute) {
-        window.open(getHubSignupUrl(location));
-    } else {
-        window.open(getHubSignupUrl());
-    }
-};
-
-type TLoginUrl = {
-    language: string;
-};
-
-// Simplified login URL - always use external login from brand url
-export const loginUrl = ({ language }: TLoginUrl) => {
-    return getBrandHubLoginUrl();
+    window.location.href = getBrandHubSignupUrl();
 };

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, Modal } from '@deriv/components';
 import { redirectToLogin, redirectToSignUp } from '@deriv/shared';
-import { getLanguage, localize } from '@deriv/translations';
+import { localize } from '@deriv/translations';
 
 type TAuthorizationRequiredModal = {
     is_visible: boolean;
@@ -10,7 +10,7 @@ type TAuthorizationRequiredModal = {
     is_logged_in: boolean;
 };
 
-const AuthorizationRequiredModal = ({ is_visible, toggleModal, is_logged_in }: TAuthorizationRequiredModal) => (
+const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => (
     <Modal
         id='dt_authorization_required_modal'
         is_open={is_visible}
@@ -20,12 +20,7 @@ const AuthorizationRequiredModal = ({ is_visible, toggleModal, is_logged_in }: T
     >
         <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
         <Modal.Footer>
-            <Button
-                has_effect
-                text={localize('Log in')}
-                onClick={() => redirectToLogin(is_logged_in, getLanguage())}
-                secondary
-            />
+            <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
             <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
         </Modal.Footer>
     </Modal>

--- a/packages/trader/src/App/Components/Routes/route-with-sub-routes.tsx
+++ b/packages/trader/src/App/Components/Routes/route-with-sub-routes.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Redirect, Route, RouteComponentProps } from 'react-router-dom';
 
 import { default_title, isEmptyObject, redirectToLogin, removeBranchName, routes } from '@deriv/shared';
-import { getLanguage } from '@deriv/translations';
 import { observer, useStore } from '@deriv/stores';
 
 import Page404 from 'Modules/Page404';
@@ -40,7 +39,7 @@ const RouteWithSubRoutes = observer((route: TRouteWithSubRoutesProps) => {
         } else if (is_valid_route && route.is_authenticated && !route.is_logging_in && !is_logged_in) {
             // Only redirect if client store is initialized - prevents race condition during page refresh
             if (is_client_store_initialized) {
-                redirectToLogin(is_logged_in, getLanguage());
+                redirectToLogin();
             }
         } else {
             const default_subroute = route.routes ? route.routes.find(r => r.default) : {};

--- a/packages/trader/src/AppV2/Components/ServiceErrorSheet/service-error-sheet.tsx
+++ b/packages/trader/src/AppV2/Components/ServiceErrorSheet/service-error-sheet.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router';
 
-import { getBrandHubUrl, isEmptyObject, redirectToLogin, redirectToSignUp, routes } from '@deriv/shared';
+import { getBrandHubUrl, isEmptyObject, redirectToLogin, redirectToSignUp } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { getLanguage, Localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { ActionSheet } from '@deriv-com/quill-ui';
 
 import { checkIsServiceModalError, SERVICE_ERROR } from 'AppV2/Utils/layout-utils';
@@ -13,11 +12,10 @@ import ServiceErrorDescription from './service-error-description';
 
 const ServiceErrorSheet = observer(() => {
     const [is_open, setIsOpen] = useState(false);
-    const { common, client, ui } = useStore();
+    const { common, client } = useStore();
     const { is_virtual } = client;
     const { services_error, resetServicesError } = common;
     const { clearPurchaseInfo, requestProposal: resetPurchase } = useTraderStore();
-    const history = useHistory();
 
     const { code, message, type } = services_error || {};
     const is_insufficient_balance = code === SERVICE_ERROR.INSUFFICIENT_BALANCE;
@@ -70,7 +68,7 @@ const ServiceErrorSheet = observer(() => {
                     content: <Localize i18n_default_text='Login' />,
                     onAction: () => {
                         resetServicesError();
-                        redirectToLogin(false, getLanguage());
+                        redirectToLogin();
                     },
                 },
             };

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -830,7 +830,7 @@ export default class TradeStore extends BaseStore {
 
         if (!active_symbols?.length) {
             await WS.wait('get_settings');
-            showUnavailableLocationError(showError, is_logged_in);
+            showUnavailableLocationError(showError);
         }
         await this.processNewValuesAsync({ active_symbols });
     }


### PR DESCRIPTION
This pull request refactors authentication logic and updates UI components to simplify login and signup flows. The main changes include removing conditional and language-based logic from authentication redirects, introducing a new utility for the Brand Hub signup URL, and updating modal and menu components to use the new authentication methods.

**Authentication Logic Simplification**
* Refactored `redirectToLogin` and `redirectToSignUp` in `login.ts` to always use the Brand Hub URLs, removing conditional parameters, language handling, and session storage for redirects.
* Removed the `loginUrl` function and related type definitions from `login.ts`, further streamlining the authentication utilities.

**Utility Functions**
* Added `getBrandHubSignupUrl` to `brand.ts` for consistent signup URL generation.

**UI Component Updates**
* Updated `AuthorizationRequiredModal` in `authorization-required-modal.tsx` to use the simplified `redirectToLogin` and `redirectToSignUp` functions, removing dependency on user login state and language. [[1]](diffhunk://#diff-c2716b1c3fc1a7124bc18b65abfb0fa9175c3f003966825f495cdc6d25ece573L5-R13) [[2]](diffhunk://#diff-c2716b1c3fc1a7124bc18b65abfb0fa9175c3f003966825f495cdc6d25ece573L23-R23)
* Modified `toggle-menu-drawer.jsx` to conditionally show the Brand Hub menu item only when the user is logged in. [[1]](diffhunk://#diff-d863554aa1bd2501ddf52b8fc58a849db34a5efb914b62f10240f90060f10904R187) [[2]](diffhunk://#diff-d863554aa1bd2501ddf52b8fc58a849db34a5efb914b62f10240f90060f10904R199)