### PR TITLE
Update derivatives-charts to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
                 "@babel/preset-typescript": "^7.24.7",
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.0.5",
+                "@deriv-com/derivatives-charts": "^1.1.0",
                 "@types/react-transition-group": "^4.4.4",
                 "babel-jest": "^29.7.0",
                 "dotenv": "^8.2.0",
@@ -2255,9 +2255,9 @@
             }
         },
         "node_modules/@deriv-com/derivatives-charts": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.0.5.tgz",
-            "integrity": "sha512-oJ2f2g+AdbanfUYkbIo+4PKCFY9sNMMy9fnbs3ZBEd/d8zXB+xnPIlgNBhU4tnyAddCzGItyNhppEmEPmM00rg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.1.0.tgz",
+            "integrity": "sha512-u+ICER2ItLF8fpkaiVyLvqJ2A9zSyXuTT04GItE4LxaeIcH0MkbWZ/J28oMGToJUf5kE+DV7QPmkwfYNqmqRFg==",
             "license": "ISC",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
@@ -32190,7 +32190,7 @@
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "1.31.3",
                 "@deriv-com/auth-client": "1.5.2",
-                "@deriv-com/derivatives-charts": "^1.0.5",
+                "@deriv-com/derivatives-charts": "^1.1.0",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/translations": "1.3.9",
@@ -33160,7 +33160,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.0.5",
+                "@deriv-com/derivatives-charts": "^1.1.0",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/ui": "1.36.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/preset-typescript": "^7.24.7",
         "@deriv-com/analytics": "1.31.3",
-        "@deriv-com/derivatives-charts": "^1.0.5",
+        "@deriv-com/derivatives-charts": "^1.1.0",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^29.7.0",
         "dotenv": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,7 +103,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.0.5",
+        "@deriv-com/derivatives-charts": "^1.1.0",
         "@deriv/quill-icons": "2.2.1",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -93,7 +93,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.0.5",
+        "@deriv-com/derivatives-charts": "^1.1.0",
         "@deriv/api": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv-com/derivatives-charts to 1.1.0