### PR TITLE
Akmal / feat: ensure duration_unit resets to minutes for all Vanilla contract types

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
@@ -311,6 +311,28 @@ export const ContractType = (() => {
     };
 
     const getDurationUnit = (duration_unit: string, contract_type: string) => {
+        // For ALL Vanilla contracts, always return 'm' (minutes) to ensure proper duration reset behavior
+        // This fixes the issue where switching back to Vanilla contracts would show "5 Days" instead of "5 minutes"
+        // Vanilla contracts include: vanilla_call, vanilla_put, rise_fall, rise_fall_equal, call_put, etc.
+        const vanillaContractTypes = [
+            'vanilla_call',
+            'vanilla_put',
+            'vanillalongcall',
+            'vanillalongput',
+            'call_put',
+            'rise_fall',
+            'rise_fall_equal',
+            'higher_lower',
+            'call',
+            'put',
+        ];
+
+        if (vanillaContractTypes.includes(contract_type)) {
+            return {
+                duration_unit: 'm',
+            };
+        }
+
         const duration_units =
             (getPropertyValue(available_contract_types, [
                 contract_type,
@@ -323,8 +345,10 @@ export const ContractType = (() => {
             arr_units.push(obj.value);
         });
 
+        const resolved_duration_unit = getArrayDefaultValue(arr_units, duration_unit);
+
         return {
-            duration_unit: getArrayDefaultValue(arr_units, duration_unit),
+            duration_unit: resolved_duration_unit || duration_unit,
         };
     };
 

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -947,12 +947,19 @@ export default class TradeStore extends BaseStore {
                 this.expiry_time = null;
                 this.expiry_date = null;
 
+                // ALWAYS reset duration_unit to minutes for ALL Vanilla contract switches
+                // This ensures that switching back to Vanilla always shows minutes, not days/hours
+                this.duration_unit = 'm';
+
+                // Also reset UI store duration units to ensure dropdowns show minutes
+                this.root_store.ui.advanced_duration_unit = 'm';
+                this.root_store.ui.simple_duration_unit = 'm';
+
                 // Only reset other defaults when switching from non-Vanilla to Vanilla
                 if (!was_vanilla) {
                     // Reset to safe defaults for Vanilla contracts
                     // Use minutes (m) with duration 5 to ensure relative barriers (+/-)
                     this.duration = 5;
-                    this.duration_unit = 'm';
                     this.barrier_1 = '+0.1';
                 }
             }


### PR DESCRIPTION
## Changes:

feat: ensure duration_unit resets to minutes for all Vanilla contract types
