### PR TITLE
Farabi/grwt-6942/fix-proposal-duration-request

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
@@ -311,9 +311,9 @@ export const ContractType = (() => {
     };
 
     const getDurationUnit = (duration_unit: string, contract_type: string) => {
-        // For ALL Vanilla contracts, always return 'm' (minutes) to ensure proper duration reset behavior
-        // This fixes the issue where switching back to Vanilla contracts would show "5 Days" instead of "5 minutes"
-        // Vanilla contracts include: vanilla_call, vanilla_put, rise_fall, rise_fall_equal, call_put, etc.
+        // For Vanilla contracts, validate that the duration_unit is supported
+        // If not supported, default to 'm' (minutes)
+        // This preserves user selection while ensuring valid duration units
         const vanillaContractTypes = [
             'vanilla_call',
             'vanilla_put',
@@ -328,6 +328,16 @@ export const ContractType = (() => {
         ];
 
         if (vanillaContractTypes.includes(contract_type)) {
+            // Get available duration units for this contract type
+            const { duration_units_list } = getDurationUnitsList(contract_type);
+            const available_units = duration_units_list.map(unit => unit.value);
+
+            // If the requested duration_unit is available, use it; otherwise default to 'm'
+            if (available_units.includes(duration_unit)) {
+                return {
+                    duration_unit,
+                };
+            }
             return {
                 duration_unit: 'm',
             };


### PR DESCRIPTION
This pull request updates the logic for determining the duration unit for Vanilla contracts in `contract-type.ts`. The main improvement is that the code now validates the requested duration unit against the contract's supported units, preserving user selection when possible while ensuring only valid units are used.

**Improvements to duration unit validation for Vanilla contracts:**

* The `getDurationUnit` function now checks if the requested `duration_unit` is supported for the given Vanilla contract type, using the list returned by `getDurationUnitsList`. If the unit is supported, it is used; otherwise, it defaults to `'m'` (minutes). This change ensures users see their intended duration unit when switching between contracts, while preventing invalid selections. [[1]](diffhunk://#diff-d91edda55bb2d178afef3d47bc4767e0a69c4aab15f3c656c40c34f1ad531341L314-R316) [[2]](diffhunk://#diff-d91edda55bb2d178afef3d47bc4767e0a69c4aab15f3c656c40c34f1ad531341R331-R340)