### PR TITLE
Update derivatives-charts to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
                 "@babel/preset-typescript": "^7.24.7",
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.4",
                 "@types/react-transition-group": "^4.4.4",
                 "babel-jest": "^29.7.0",
                 "dotenv": "^8.2.0",
@@ -2255,9 +2255,9 @@
             }
         },
         "node_modules/@deriv-com/derivatives-charts": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.1.3.tgz",
-            "integrity": "sha512-9GQZyQgPLrPBqlpFAkyzOy7m39t9DRR9wHa/2e/uruBz8dJvbrVR9FLUZVRL1TV4oGqm/Nl5cs9sebmm3GRilw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.1.4.tgz",
+            "integrity": "sha512-LbCIWMpP7jPBd5hNT7hGEzIUdGvOSfM/XDMhH4A+klG10yjs+lUtX6y25NSxkRiLjTGhvFCt9AWB7pw9kDMadw==",
             "license": "ISC",
             "dependencies": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -2683,10 +2683,6 @@
         },
         "node_modules/@deriv/trader": {
             "resolved": "packages/trader",
-            "link": true
-        },
-        "node_modules/@deriv/translations": {
-            "resolved": "packages/translations",
             "link": true
         },
         "node_modules/@deriv/utils": {
@@ -31964,12 +31960,12 @@
                 "@binary-com/binary-document-uploader": "^2.4.8",
                 "@deriv-com/analytics": "1.31.6",
                 "@deriv-com/auth-client": "1.5.2",
+                "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv-com/utils": "^0.0.42",
                 "@deriv/deriv-api": "^1.0.15",
                 "@deriv/shared": "^1.0.0",
                 "@deriv/stores": "^1.0.0",
-                "@deriv/translations": "^1.0.0",
                 "@deriv/utils": "^1.0.0",
                 "@simplewebauthn/browser": "^8.3.4",
                 "@simplewebauthn/typescript-types": "^8.3.4",
@@ -32084,11 +32080,11 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@cloudflare/stream-react": "^1.9.1",
+                "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv/api": "^1.0.0",
                 "@deriv/shared": "^1.0.0",
                 "@deriv/stores": "^1.0.0",
-                "@deriv/translations": "^1.0.0",
                 "@types/react-virtualized": "^9.21.21",
                 "classnames": "^2.2.6",
                 "clsx": "^2.1.1",
@@ -32177,7 +32173,7 @@
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "1.31.3",
                 "@deriv-com/auth-client": "1.5.2",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.4",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/translations": "1.3.9",
@@ -32191,7 +32187,6 @@
                 "@deriv/shared": "^1.0.0",
                 "@deriv/stores": "^1.0.0",
                 "@deriv/trader": "^3.8.0",
-                "@deriv/translations": "^1.0.0",
                 "@deriv/utils": "^1.0.0",
                 "acorn": "^6.1.1",
                 "canvas-toBlob": "^1.0.0",
@@ -32984,6 +32979,7 @@
             "dependencies": {
                 "@babel/polyfill": "^7.12.1 ",
                 "@deriv-com/analytics": "1.31.3",
+                "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv/api": "^1.0.0",
                 "@deriv/api-types": "1.0.172",
@@ -32991,7 +32987,6 @@
                 "@deriv/deriv-api": "^1.0.15",
                 "@deriv/shared": "^1.0.0",
                 "@deriv/stores": "^1.0.0",
-                "@deriv/translations": "^1.0.0",
                 "@types/react": "^18.0.7",
                 "@types/react-dom": "^18.0.0",
                 "@types/react-loadable": "^5.5.6",
@@ -33078,10 +33073,10 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@deriv-com/analytics": "1.31.3",
+                "@deriv-com/translations": "1.3.9",
                 "@deriv-com/utils": "^0.0.42",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/quill-icons": "2.2.1",
-                "@deriv/translations": "^1.0.0",
                 "@types/js-cookie": "^3.0.1",
                 "@types/react-loadable": "^5.5.6",
                 "canvas-toBlob": "^1.0.0",
@@ -33147,9 +33142,10 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.4",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
+                "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv-com/utils": "^0.0.42",
                 "@deriv/api": "^1.0.0",
@@ -33159,7 +33155,6 @@
                 "@deriv/quill-icons": "2.2.1",
                 "@deriv/shared": "^1.0.0",
                 "@deriv/stores": "^1.0.0",
-                "@deriv/translations": "^1.0.0",
                 "@deriv/utils": "^1.0.0",
                 "@lottiefiles/dotlottie-react": "0.7.2",
                 "@types/react-loadable": "^5.5.6",
@@ -33246,6 +33241,7 @@
         "packages/translations": {
             "name": "@deriv/translations",
             "version": "1.0.0",
+            "extraneous": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "commander": "^3.0.2",
@@ -33264,28 +33260,6 @@
             },
             "engines": {
                 "node": "18.x"
-            }
-        },
-        "packages/translations/node_modules/commander": {
-            "version": "3.0.2",
-            "license": "MIT"
-        },
-        "packages/translations/node_modules/glob": {
-            "version": "7.2.3",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/utils": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/preset-typescript": "^7.24.7",
         "@deriv-com/analytics": "1.31.3",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.4",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^29.7.0",
         "dotenv": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,7 +103,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.4",
         "@deriv/quill-icons": "2.2.1",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -93,7 +93,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.4",
         "@deriv/api": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv-com/derivatives-charts to 1.1.4