### PR TITLE
Update derivatives-charts to 1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
                 "@babel/preset-typescript": "^7.24.7",
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.6",
                 "@types/react-transition-group": "^4.4.4",
                 "babel-jest": "^29.7.0",
                 "dotenv": "^8.2.0",
@@ -2555,9 +2555,9 @@
             }
         },
         "node_modules/@deriv-com/derivatives-charts": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.1.3.tgz",
-            "integrity": "sha512-9GQZyQgPLrPBqlpFAkyzOy7m39t9DRR9wHa/2e/uruBz8dJvbrVR9FLUZVRL1TV4oGqm/Nl5cs9sebmm3GRilw==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@deriv-com/derivatives-charts/-/derivatives-charts-1.1.6.tgz",
+            "integrity": "sha512-jgM6baaeMleZokzWmYiMPI7mME1UU4oil8QcXeHWR9nCXw7piNgNL6Xnh4pxwcjR6TUnmlqR0JapzRGrveSdeA==",
             "license": "ISC",
             "dependencies": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -33099,7 +33099,7 @@
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "1.31.3",
                 "@deriv-com/auth-client": "1.5.2",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.6",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/translations": "1.3.9",
@@ -34163,7 +34163,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@deriv-com/analytics": "1.31.3",
-                "@deriv-com/derivatives-charts": "^1.1.3",
+                "@deriv-com/derivatives-charts": "^1.1.6",
                 "@deriv-com/quill-tokens": "2.0.4",
                 "@deriv-com/quill-ui": "1.24.4",
                 "@deriv-com/translations": "1.3.9",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
         "@babel/preset-typescript": "^7.24.7",
         "@deriv-com/analytics": "1.31.3",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.6",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^29.7.0",
         "dotenv": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,7 @@
         "@datadog/browser-rum": "^5.11.0",
         "@deriv-com/analytics": "1.31.3",
         "@deriv-com/auth-client": "1.5.2",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.6",
         "@deriv-com/quill-tokens": "2.0.4",
         "@deriv-com/quill-ui": "1.24.4",
         "@deriv-com/translations": "1.3.9",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -86,7 +86,7 @@
     },
     "dependencies": {
         "@deriv-com/analytics": "1.31.3",
-        "@deriv-com/derivatives-charts": "^1.1.3",
+        "@deriv-com/derivatives-charts": "^1.1.6",
         "@deriv-com/quill-tokens": "2.0.4",
         "@deriv-com/quill-ui": "1.24.4",
         "@deriv-com/ui": "1.36.4",


### PR DESCRIPTION
This PR updates @deriv-com/derivatives-charts to 1.1.6