### PR TITLE
Farabi/fix-localize-method-to-useTransalations

### DIFF
--- a/packages/components/src/components/video-player/playback-rate-control.tsx
+++ b/packages/components/src/components/video-player/playback-rate-control.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import Dropdown from '../dropdown';
 import clsx from 'clsx';
+
 import { StandalonePlaybackSpeedFillIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
+
+import Dropdown from '../dropdown';
 
 type TPlaybackRateControl = {
     onPlaybackRateChange: (new_value: number) => void;
@@ -19,6 +21,7 @@ const PlaybackRateControl = ({
     is_v2 = false,
     show_controls = false,
 }: TPlaybackRateControl) => {
+    const { localize } = useTranslations();
     const playback_rate_list = [
         { text: '0.25x', value: '0.25' },
         { text: '0.5x', value: '0.5' },

--- a/packages/components/src/components/wallet-card/wallet-card.tsx
+++ b/packages/components/src/components/wallet-card/wallet-card.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
-import { localize } from '@deriv-com/translations';
+
+import { LegacyCheck2pxIcon, LegacyPlus2pxIcon, LegacyWonIcon } from '@deriv/quill-icons';
+import { isMobile } from '@deriv/shared';
+import { useTranslations } from '@deriv-com/translations';
+
 import Badge from '../badge';
 import Button from '../button';
 import Text from '../text';
-import { isMobile } from '@deriv/shared';
 import { WalletIcon } from '../wallet-icon';
-import { LegacyCheck2pxIcon, LegacyPlus2pxIcon, LegacyWonIcon } from '@deriv/quill-icons';
+
 import './wallet-card.scss';
 
 type TWalletCardProps = {
@@ -49,82 +52,85 @@ const WalletCard: React.FC<React.PropsWithChildren<TWalletCardProps>> = ({
     wallet,
     size = 'medium',
     state = 'default',
-}) => (
-    <div className={`wallet-card wallet-card--${size} wallet-card--${state}`}>
-        <div
-            className={`wallet-card__container wallet-card__container--${state} wallet-card__container--${size} ${wallet.gradient_class}`}
-        >
-            {size !== 'small' && <div className='wallet-card__shine' />}
+}) => {
+    const { localize } = useTranslations();
+    return (
+        <div className={`wallet-card wallet-card--${size} wallet-card--${state}`}>
             <div
-                className={classNames('wallet-card__container-fade', {
-                    [`wallet-card__container-fade--${state}`]: state,
-                })}
-            />
-            {size === 'small' && <IconComponent size={size} icon_type={wallet.icon_type} icon_name={wallet.icon} />}
-            {size !== 'small' && (
-                <div className={`wallet-card__content wallet-card__content--${size}`}>
-                    <div className='wallet-card__top-wrapper'>
-                        <IconComponent size={size} icon_type={wallet.icon_type} icon_name={wallet.icon} />
-                        {wallet.jurisdiction_title === 'virtual' ? (
-                            <Badge label={localize('Demo')} type='contained' background_color='blue' />
-                        ) : (
-                            <Badge
-                                custom_color='var(--color-text-primary)'
-                                label={wallet.jurisdiction_title.toUpperCase()}
-                                type='bordered'
-                            />
-                        )}
-                    </div>
+                className={`wallet-card__container wallet-card__container--${state} wallet-card__container--${size} ${wallet.gradient_class}`}
+            >
+                {size !== 'small' && <div className='wallet-card__shine' />}
+                <div
+                    className={classNames('wallet-card__container-fade', {
+                        [`wallet-card__container-fade--${state}`]: state,
+                    })}
+                />
+                {size === 'small' && <IconComponent size={size} icon_type={wallet.icon_type} icon_name={wallet.icon} />}
+                {size !== 'small' && (
+                    <div className={`wallet-card__content wallet-card__content--${size}`}>
+                        <div className='wallet-card__top-wrapper'>
+                            <IconComponent size={size} icon_type={wallet.icon_type} icon_name={wallet.icon} />
+                            {wallet.jurisdiction_title === 'virtual' ? (
+                                <Badge label={localize('Demo')} type='contained' background_color='blue' />
+                            ) : (
+                                <Badge
+                                    custom_color='var(--color-text-primary)'
+                                    label={wallet.jurisdiction_title.toUpperCase()}
+                                    type='bordered'
+                                />
+                            )}
+                        </div>
 
-                    <div className='wallet-card__bottom-wrapper'>
-                        {state !== 'add' && state !== 'added' ? (
-                            <React.Fragment>
-                                <Text color='primary' size={isMobile() ? 'xxxxs' : 'xxxs'}>
-                                    {wallet.name}
-                                </Text>
-                                <Text color='primary' weight='bold' size={isMobile() ? 'xxs' : 'xs'}>
-                                    {wallet.balance} {wallet.currency}
-                                </Text>
-                            </React.Fragment>
-                        ) : (
-                            <Button
-                                className={`wallet-card__wallet-button wallet-card__wallet-button--${state}`}
-                                classNameSpan='wallet-card__wallet-button-text'
-                                icon={
-                                    state === 'added' ? (
-                                        <LegacyCheck2pxIcon
-                                            className='wallet-card__wallet-button-icon'
-                                            width={12}
-                                            height={12}
-                                            fill='var(--color-text-primary)'
-                                        />
-                                    ) : (
-                                        <LegacyPlus2pxIcon
-                                            className='wallet-card__wallet-button-icon'
-                                            width={12}
-                                            height={12}
-                                            fill='var(--color-text-primary)'
-                                        />
-                                    )
-                                }
-                                text={state === 'added' ? localize('Added') : localize('Add')}
-                                is_disabled={state === 'added'}
-                            />
-                        )}
+                        <div className='wallet-card__bottom-wrapper'>
+                            {state !== 'add' && state !== 'added' ? (
+                                <React.Fragment>
+                                    <Text color='primary' size={isMobile() ? 'xxxxs' : 'xxxs'}>
+                                        {wallet.name}
+                                    </Text>
+                                    <Text color='primary' weight='bold' size={isMobile() ? 'xxs' : 'xs'}>
+                                        {wallet.balance} {wallet.currency}
+                                    </Text>
+                                </React.Fragment>
+                            ) : (
+                                <Button
+                                    className={`wallet-card__wallet-button wallet-card__wallet-button--${state}`}
+                                    classNameSpan='wallet-card__wallet-button-text'
+                                    icon={
+                                        state === 'added' ? (
+                                            <LegacyCheck2pxIcon
+                                                className='wallet-card__wallet-button-icon'
+                                                width={12}
+                                                height={12}
+                                                fill='var(--color-text-primary)'
+                                            />
+                                        ) : (
+                                            <LegacyPlus2pxIcon
+                                                className='wallet-card__wallet-button-icon'
+                                                width={12}
+                                                height={12}
+                                                fill='var(--color-text-primary)'
+                                            />
+                                        )
+                                    }
+                                    text={state === 'added' ? localize('Added') : localize('Add')}
+                                    is_disabled={state === 'added'}
+                                />
+                            )}
+                        </div>
                     </div>
+                )}
+            </div>
+            {state === 'active' && (
+                <div className={`wallet-card__active-icon wallet-card__active-icon--${size}`}>
+                    <LegacyWonIcon
+                        data-testid='dt_ic_checkmark_circle'
+                        width={size === 'small' ? 16 : 32}
+                        height={size === 'small' ? 16 : 32}
+                        fill='var(--color-status-success)'
+                    />
                 </div>
             )}
         </div>
-        {state === 'active' && (
-            <div className={`wallet-card__active-icon wallet-card__active-icon--${size}`}>
-                <LegacyWonIcon
-                    data-testid='dt_ic_checkmark_circle'
-                    width={size === 'small' ? 16 : 32}
-                    height={size === 'small' ? 16 : 32}
-                    fill='var(--color-status-success)'
-                />
-            </div>
-        )}
-    </div>
-);
+    );
+};
 export default WalletCard;

--- a/packages/core/src/App/AppContent.tsx
+++ b/packages/core/src/App/AppContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { useRemoteConfig, useGrowthbookGetFeatureValue, useGrowthbookIsOn, useIntercom, useLiveChat } from '@deriv/api';
+import { useGrowthbookGetFeatureValue, useGrowthbookIsOn, useIntercom, useLiveChat, useRemoteConfig } from '@deriv/api';
 import { observer, useStore } from '@deriv/stores';
 import { ThemeProvider } from '@deriv-com/quill-ui';
 import { useTranslations } from '@deriv-com/translations';

--- a/packages/core/src/App/Components/Elements/CookieBanner/cookie-banner.jsx
+++ b/packages/core/src/App/Components/Elements/CookieBanner/cookie-banner.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, StaticUrl } from '@deriv/components';
-import { localize, Localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 const CookieBanner = ({ onAccept, onDecline, is_open, is_dark_mode }) => (
     <div
@@ -20,7 +20,7 @@ const CookieBanner = ({ onAccept, onDecline, is_open, is_dark_mode }) => (
             />
         </div>
         <Button className='cookie-banner__btn-dont-accept' secondary onClick={onDecline}>
-            {localize('Don’t accept')}
+            <Localize i18n_default_text='Don’t accept' />
         </Button>
         <Button
             id='dt_core_cookie-banner_accept-btn'
@@ -28,7 +28,7 @@ const CookieBanner = ({ onAccept, onDecline, is_open, is_dark_mode }) => (
             secondary
             onClick={onAccept}
         >
-            {localize('Accept')}
+            <Localize i18n_default_text='Accept' />
         </Button>
     </div>
 );

--- a/packages/core/src/App/Components/Elements/Errors/error-component.jsx
+++ b/packages/core/src/App/Components/Elements/Errors/error-component.jsx
@@ -1,9 +1,10 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
 import { PageErrorContainer } from '@deriv/components';
 import { routes } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 const ErrorComponent = ({
     header,
@@ -17,6 +18,7 @@ const ErrorComponent = ({
     should_redirect = true,
 }) => {
     const history = useHistory();
+    const { localize } = useTranslations();
 
     React.useEffect(() => {
         if (!history) return undefined;

--- a/packages/core/src/App/Components/Elements/Modals/deriv-real-account-required-modal.jsx
+++ b/packages/core/src/App/Components/Elements/Modals/deriv-real-account-required-modal.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+
 import { Dialog } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
 import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+
 import './deriv-real-account-required-modal.scss';
 
 const DerivRealAccountRequiredModal = observer(() => {
+    const { localize } = useTranslations();
     const { ui, traders_hub } = useStore();
     const { is_eu_user } = traders_hub;
     const {

--- a/packages/core/src/App/Components/Elements/NotificationMessage/close-button.jsx
+++ b/packages/core/src/App/Components/Elements/NotificationMessage/close-button.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-const CloseButton = ({ onClick, className }) => (
-    <button className={className} type='button' onClick={onClick} aria-label={localize('Close')} />
-);
+const CloseButton = ({ onClick, className }) => {
+    const { localize } = useTranslations();
+    return <button className={className} type='button' onClick={onClick} aria-label={localize('Close')} />;
+};
 
 CloseButton.propTypes = {
     className: PropTypes.string,

--- a/packages/core/src/App/Components/Elements/WhatsApp/whatsapp.tsx
+++ b/packages/core/src/App/Components/Elements/WhatsApp/whatsapp.tsx
@@ -1,13 +1,14 @@
 import React, { Fragment } from 'react';
 
-import { Popover } from '@deriv/components';
 import { useIsIntercomAvailable, useIsLiveChatWidgetAvailable } from '@deriv/api';
-import { localize } from '@deriv-com/translations';
+import { Popover } from '@deriv/components';
+import { LegacyWhatsappIcon } from '@deriv/quill-icons';
+import { useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 import { URLConstants } from '@deriv-com/utils';
-import { LegacyWhatsappIcon } from '@deriv/quill-icons';
 
 const WhatsApp = ({ showPopover, onClick }: { showPopover?: boolean; onClick?: () => void }) => {
+    const { localize } = useTranslations();
     const { isDesktop } = useDevice();
 
     const { is_livechat_available } = useIsLiveChatWidgetAvailable();

--- a/packages/core/src/App/Components/Layout/Footer/account-limits.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/account-limits.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
+
+import { useAccountSettingsRedirect } from '@deriv/api';
 import { Popover } from '@deriv/components';
 import { LegacyAccountLimitsIcon } from '@deriv/quill-icons';
-import { useAccountSettingsRedirect } from '@deriv/api';
-import { localize } from '@deriv-com/translations';
 import { observer } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
 
 export const AccountLimits = observer(({ showPopover }) => {
     // Use the useAccountSettingsRedirect hook with 'account-limits' as the redirect_to value
     const { redirect_url } = useAccountSettingsRedirect('account-limits');
+    const { localize } = useTranslations();
 
     return (
         <a className='footer__link' href={redirect_url}>

--- a/packages/core/src/App/Components/Layout/Footer/help-centre.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/help-centre.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
+
 import { Popover, StaticUrl } from '@deriv/components';
 import { LegacyHelpCentreIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-export const HelpCentre = ({ showPopover }) => (
-    <StaticUrl href='/help-centre/' id='dt_help_centre' aria-label={localize('Help centre')} className='footer__link'>
-        {showPopover ? (
-            <Popover
-                classNameBubble='help-centre__tooltip'
-                alignment='top'
-                message={localize('Help centre')}
-                zIndex={9999}
-            >
+export const HelpCentre = ({ showPopover }) => {
+    const { localize } = useTranslations();
+    return (
+        <StaticUrl
+            href='/help-centre/'
+            id='dt_help_centre'
+            aria-label={localize('Help centre')}
+            className='footer__link'
+        >
+            {showPopover ? (
+                <Popover
+                    classNameBubble='help-centre__tooltip'
+                    alignment='top'
+                    message={localize('Help centre')}
+                    zIndex={9999}
+                >
+                    <LegacyHelpCentreIcon className='footer__icon' iconSize='xs' />
+                </Popover>
+            ) : (
                 <LegacyHelpCentreIcon className='footer__icon' iconSize='xs' />
-            </Popover>
-        ) : (
-            <LegacyHelpCentreIcon className='footer__icon' iconSize='xs' />
-        )}
-    </StaticUrl>
-);
+            )}
+        </StaticUrl>
+    );
+};

--- a/packages/core/src/App/Components/Layout/Footer/network-status.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/network-status.jsx
@@ -1,11 +1,13 @@
+import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+
 import { Popover } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
 import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
 
 const NetworkStatus = observer(({ is_mobile }) => {
+    const { localize } = useTranslations();
     const { common } = useStore();
     const { network_status: status } = common;
 

--- a/packages/core/src/App/Components/Layout/Footer/regulatory-information.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/regulatory-information.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+
 import { Modal, Popover } from '@deriv/components';
 import { LegacyRegulatoryInformationIcon } from '@deriv/quill-icons';
-import { localize, Localize } from '@deriv-com/translations';
 import { deriv_urls } from '@deriv/shared';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 const MFRegulatoryInformation = () => (
     <div className='footer-regulatory-information'>
@@ -28,6 +29,7 @@ const MFRegulatoryInformation = () => (
 
 export const RegulatoryInformation = ({ landing_company, is_eu, show_eu_related_content, showPopover }) => {
     const [should_show_modal, showModal] = React.useState(false);
+    const { localize } = useTranslations();
     if (!is_eu || (is_eu && !show_eu_related_content)) return null;
     const is_mf = landing_company === 'maltainvest';
     const content = (

--- a/packages/core/src/App/Components/Layout/Footer/responsible-trading.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/responsible-trading.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { Popover, StaticUrl } from '@deriv/components';
 import { LegacyVerificationIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-export const ResponsibleTrading = ({ showPopover }) => (
-    <StaticUrl href='/responsible' className='footer__link'>
-        {showPopover ? (
-            <Popover alignment='top' message={localize('Responsible trading')} zIndex={9999}>
+export const ResponsibleTrading = ({ showPopover }) => {
+    const { localize } = useTranslations();
+    return (
+        <StaticUrl href='/responsible' className='footer__link'>
+            {showPopover ? (
+                <Popover alignment='top' message={localize('Responsible trading')} zIndex={9999}>
+                    <LegacyVerificationIcon className='footer__icon ic-deriv__icon' iconSize='xs' />
+                </Popover>
+            ) : (
                 <LegacyVerificationIcon className='footer__icon ic-deriv__icon' iconSize='xs' />
-            </Popover>
-        ) : (
-            <LegacyVerificationIcon className='footer__icon ic-deriv__icon' iconSize='xs' />
-        )}
-    </StaticUrl>
-);
+            )}
+        </StaticUrl>
+    );
+};

--- a/packages/core/src/App/Components/Layout/Footer/toggle-fullscreen.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/toggle-fullscreen.jsx
@@ -1,11 +1,13 @@
-import classNames from 'classnames';
 import React from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
+
 import { Popover } from '@deriv/components';
 import { LegacyFullscreen1pxIcon, LegacyRestore1pxIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 const ToggleFullScreen = ({ showPopover }) => {
+    const { localize } = useTranslations();
     const [is_full_screen, setIsFullScreen] = React.useState(false);
 
     const fullscreen_map = {

--- a/packages/core/src/App/Components/Layout/Footer/toggle-language-settings.tsx
+++ b/packages/core/src/App/Components/Layout/Footer/toggle-language-settings.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import classNames from 'classnames';
-import { observer, useStore } from '@deriv/stores';
+
 import { Modal, Popover, Text } from '@deriv/components';
-import { useTranslations, Localize, localize } from '@deriv-com/translations';
-import 'Sass/app/modules/settings.scss';
-import LanguageSettings from '../../../Containers/SettingsModal/settings-language';
 import { TranslationFlag } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { Localize, useTranslations } from '@deriv-com/translations';
+
+import LanguageSettings from '../../../Containers/SettingsModal/settings-language';
+
+import 'Sass/app/modules/settings.scss';
 
 const ToggleLanguageSettings = observer(({ showPopover }: { showPopover?: boolean }) => {
+    const { localize } = useTranslations();
     const { common, ui } = useStore();
     const { currentLang } = useTranslations();
     const { is_language_settings_modal_on, toggleLanguageSettingsModal } = ui;

--- a/packages/core/src/App/Components/Layout/Footer/toggle-settings.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/toggle-settings.jsx
@@ -1,9 +1,11 @@
+import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+
 import { Modal, Popover, VerticalTab } from '@deriv/components';
 import { LegacySettings1pxIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
+
 import 'Sass/app/modules/settings.scss';
 
 const ModalContent = ({ settings_extension }) => {
@@ -22,6 +24,7 @@ const ToggleSettings = ({
     settings_extension,
     showPopover,
 }) => {
+    const { localize } = useTranslations();
     const toggle_settings_class = classNames('ic-settings', 'footer__link', {
         'ic-settings--active': is_settings_visible,
     });

--- a/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/menu-title.tsx
+++ b/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/menu-title.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { observer, useStore } from '@deriv/stores';
+
 import { Text } from '@deriv/components';
-import { localize, Localize } from '@deriv-com/translations';
 import { TranslationFlag } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 const MenuTitle = observer(() => {
+    const { localize } = useTranslations();
     const { common, ui } = useStore();
     const { current_language } = common;
     const { is_mobile_language_menu_open, setMobileLanguageMenuOpen } = ui;

--- a/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/mobile-language-menu.tsx
+++ b/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/mobile-language-menu.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
+
 import { MobileDrawer } from '@deriv/components';
-import { observer, useStore } from '@deriv/stores';
-import { getAllowedLanguages, localize } from '@deriv-com/translations';
-import { LanguageLink } from 'App/Components/Routes';
 import { UNSUPPORTED_LANGUAGES } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { getAllowedLanguages, useTranslations } from '@deriv-com/translations';
+
+import { LanguageLink } from 'App/Components/Routes';
 
 type TMobileLanguageMenu = {
     expandSubMenu: (prop: boolean) => void;
@@ -15,6 +17,7 @@ const MobileLanguageMenu = observer(({ expandSubMenu, toggleDrawer }: TMobileLan
     const { common, ui } = useStore();
     const { is_language_changing } = common;
     const { is_mobile_language_menu_open, setMobileLanguageMenuOpen } = ui;
+    const { localize } = useTranslations();
 
     const allowed_languages = Object.keys(getAllowedLanguages(UNSUPPORTED_LANGUAGES));
 

--- a/packages/core/src/App/Components/Layout/Header/account-actions.tsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+
 import { Button } from '@deriv/components';
 import { formatMoney } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import { LoginButtonV2 } from './login-button-v2';
@@ -25,9 +26,10 @@ const AccountInfo = React.lazy(
         )
 );
 
-const LogoutButton = ({ onClickLogout }: { onClickLogout: () => void }) => (
-    <Button className='acc-info__button' has_effect text={localize('Log out')} onClick={onClickLogout} />
-);
+const LogoutButton = ({ onClickLogout }: { onClickLogout: () => void }) => {
+    const { localize } = useTranslations();
+    return <Button className='acc-info__button' has_effect text={localize('Log out')} onClick={onClickLogout} />;
+};
 
 const LoggedOutView = () => (
     <>

--- a/packages/core/src/App/Components/Layout/Header/account-info.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
 import { Text } from '@deriv/components';
-import { Localize, localize } from '@deriv-com/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
+import { Localize, useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
-import AccountInfoWrapper from './account-info-wrapper';
+
 import AccountInfoIcon from './account-info-icon';
+import AccountInfoWrapper from './account-info-wrapper';
 
 const AccountInfo = ({ acc_switcher_disabled_message, balance, currency, is_virtual, is_disabled, is_mobile }) => {
+    const { localize } = useTranslations();
     const currency_lower = currency?.toLowerCase();
     const { isDesktop } = useDevice();
 

--- a/packages/core/src/App/Components/Layout/Header/login-button-v2.tsx
+++ b/packages/core/src/App/Components/Layout/Header/login-button-v2.tsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 import { Button } from '@deriv/components';
 import { getBrandLoginUrl } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 interface LoginButtonV2Props {
     className?: string;
 }
 
 const LoginButtonV2 = ({ className }: LoginButtonV2Props) => {
+    const { localize } = useTranslations();
     const handleLogin = () => {
         window.location.href = getBrandLoginUrl();
     };

--- a/packages/core/src/App/Components/Layout/Header/login-button.jsx
+++ b/packages/core/src/App/Components/Layout/Header/login-button.jsx
@@ -6,9 +6,10 @@ import { useTMB } from '@deriv/api';
 import { Button } from '@deriv/components';
 import { getDomainUrl, isStaging, redirectToLogin } from '@deriv/shared';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 const LoginButton = ({ className }) => {
+    const { localize } = useTranslations();
     const is_deriv_com = /deriv\.(com)/.test(window.location.hostname) || /localhost:8443/.test(window.location.host);
     const has_wallet_cookie = Cookies.get('wallet_account');
     const { isTmbEnabled } = useTMB();

--- a/packages/core/src/App/Components/Layout/Header/menu-link.tsx
+++ b/packages/core/src/App/Components/Layout/Header/menu-link.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
+
 import { Text } from '@deriv/components';
-import { routes, getStaticUrl } from '@deriv/shared';
-import { isExternalLink } from '@deriv/utils';
+import { getStaticUrl, routes } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { isExternalLink } from '@deriv/utils';
+import { useTranslations } from '@deriv-com/translations';
+
 import { BinaryLink } from 'App/Components/Routes';
 
 type TMenuLink = {
@@ -31,6 +33,7 @@ const MenuLink = observer(
         suffix_icon,
         text,
     }: Partial<TMenuLink>) => {
+        const { localize } = useTranslations();
         const is_trade_text = text === localize('Trade');
         const deriv_static_url = getStaticUrl(link_to);
         const is_external_link = deriv_static_url && isExternalLink(link_to);

--- a/packages/core/src/App/Components/Layout/Header/menu-links.jsx
+++ b/packages/core/src/App/Components/Layout/Header/menu-links.jsx
@@ -1,10 +1,13 @@
 import { useTranslation } from 'react-i18next';
+
 import { Text } from '@deriv/components';
 import { LegacyReportsIcon } from '@deriv/quill-icons';
-import { BinaryLink } from '../../Routes';
-import { observer, useStore } from '@deriv/stores';
 import { routes } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+
+import { BinaryLink } from '../../Routes';
+
 import './menu-links.scss';
 
 const MenuItems = ({ id, text, icon, link_to }) => {
@@ -24,14 +27,17 @@ const MenuItems = ({ id, text, icon, link_to }) => {
     );
 };
 
-const ReportTab = () => (
-    <MenuItems
-        id={'dt_reports_tab'}
-        icon={<LegacyReportsIcon className='header__icon' iconSize='xs' fill='var(--color-text-primary)' />}
-        text={localize('Reports')}
-        link_to={routes.reports}
-    />
-);
+const ReportTab = () => {
+    const { localize } = useTranslations();
+    return (
+        <MenuItems
+            id={'dt_reports_tab'}
+            icon={<LegacyReportsIcon className='header__icon' iconSize='xs' fill='var(--color-text-primary)' />}
+            text={localize('Reports')}
+            link_to={routes.reports}
+        />
+    );
+};
 
 const MenuLinks = observer(({ is_traders_hub_routes = false }) => {
     const { i18n } = useTranslation();

--- a/packages/core/src/App/Components/Layout/Header/signup-button.jsx
+++ b/packages/core/src/App/Components/Layout/Header/signup-button.jsx
@@ -1,19 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { Button } from '@deriv/components';
 import { redirectToSignUp } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-const SignupButton = ({ className }) => (
-    <Button
-        id='dt_signup_button'
-        className={className}
-        has_effect
-        text={localize('Sign up')}
-        onClick={redirectToSignUp}
-        primary
-    />
-);
+const SignupButton = ({ className }) => {
+    const { localize } = useTranslations();
+    return (
+        <Button
+            id='dt_signup_button'
+            className={className}
+            has_effect
+            text={localize('Sign up')}
+            onClick={redirectToSignUp}
+            primary
+        />
+    );
+};
 
 SignupButton.propTypes = {
     className: PropTypes.string,

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -6,6 +6,7 @@ import { /* useOauth2, */ useRemoteConfig } from '@deriv/api';
 import { Div100vhContainer, MobileDrawer, ToggleSwitch } from '@deriv/components';
 import {
     LegacyChartsIcon,
+    LegacyChevronRight1pxIcon,
     LegacyHelpCentreIcon,
     LegacyHomeNewIcon,
     LegacyLogout1pxIcon,
@@ -13,14 +14,13 @@ import {
     LegacyRegulatoryInformationIcon,
     LegacyResponsibleTradingIcon,
     LegacyTheme1pxIcon,
-    LegacyChevronRight1pxIcon,
 } from '@deriv/quill-icons';
 // eslint-disable-next-line no-unused-vars -- getDomainUrl kept for future handleTradershubRedirect restoration
-import { routes, getBrandHomeUrl } from '@deriv/shared';
+import { getBrandHomeUrl, routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
 // eslint-disable-next-line no-unused-vars, import/no-unresolved -- Kept for future restoration of Analytics functionality
 import { Analytics } from '@deriv-com/analytics';
+import { useTranslations } from '@deriv-com/translations';
 
 // eslint-disable-next-line no-unused-vars, import/no-unresolved -- Kept for future restoration of LiveChat functionality
 import LiveChat from 'App/Components/Elements/LiveChat';
@@ -34,6 +34,7 @@ import { MenuTitle, MobileLanguageMenu } from './Components/ToggleMenu';
 import MenuLink from './menu-link';
 
 const ToggleMenuDrawer = observer(() => {
+    const { localize } = useTranslations();
     const { ui, client, traders_hub } = useStore();
     const {
         disableApp,

--- a/packages/core/src/App/Components/Routes/language-link.tsx
+++ b/packages/core/src/App/Components/Routes/language-link.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
-import { observer, useStore } from '@deriv/stores';
+
 import { TranslationFlag, UNSUPPORTED_LANGUAGES } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
 import { getAllowedLanguages, useTranslations } from '@deriv-com/translations';
 
 export type TLanguageLink = {

--- a/packages/core/src/App/Containers/Layout/trading-hub-footer.jsx
+++ b/packages/core/src/App/Containers/Layout/trading-hub-footer.jsx
@@ -1,27 +1,30 @@
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { withRouter } from 'react-router';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { useRemoteConfig } from '@deriv/api';
+import { Popover } from '@deriv/components';
+import { isTabletOs, routes } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+
+import LiveChat from 'App/Components/Elements/LiveChat';
+import WhatsApp from 'App/Components/Elements/WhatsApp/index.ts';
 import NetworkStatus, {
     // AccountLimits as AccountLimitsFooter,
     EndpointNote,
     // HelpCentre,
     RegulatoryInformation,
-    // ResponsibleTrading,
-    ToggleSettings,
     ToggleFullScreen,
     ToggleLanguageSettings,
+    // ResponsibleTrading,
+    ToggleSettings,
 } from 'App/Components/Layout/Footer';
-import LiveChat from 'App/Components/Elements/LiveChat';
-import WhatsApp from 'App/Components/Elements/WhatsApp/index.ts';
-import ServerTime from '../server-time.jsx';
-import { routes, isTabletOs } from '@deriv/shared';
-import { observer, useStore } from '@deriv/stores';
-import DarkModeToggleIcon from 'Assets/SvgComponents/footer/ic-footer-light-theme.svg';
 import LightModeToggleIcon from 'Assets/SvgComponents/footer/ic-footer-dark-theme.svg';
-import { Popover } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
-import { useRemoteConfig } from '@deriv/api';
+import DarkModeToggleIcon from 'Assets/SvgComponents/footer/ic-footer-light-theme.svg';
+
+import ServerTime from '../server-time.jsx';
 
 const FooterIconSeparator = () => <div className='footer-icon-separator' />;
 
@@ -37,6 +40,7 @@ const FooterExtensionRenderer = (footer_extension, idx) => {
 };
 
 const TradingHubFooter = observer(() => {
+    const { localize } = useTranslations();
     const { client, common, ui, traders_hub } = useStore();
     const { show_eu_related_content } = traders_hub;
     const { has_wallet, is_logged_in, is_eu, landing_company_shortcode, is_virtual } = client;

--- a/packages/core/src/App/Containers/Modals/ready-to-deposit-modal/ready-to-deposit-modal.tsx
+++ b/packages/core/src/App/Containers/Modals/ready-to-deposit-modal/ready-to-deposit-modal.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+
 import { Dialog } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
-import { useStore, observer } from '@deriv/stores';
+import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+
 import './ready-to-deposit-modal.scss';
 
 const ReadyToDepositModal = observer(() => {
+    const { localize } = useTranslations();
     const { ui, traders_hub } = useStore();
     const { is_eu_user } = traders_hub;
     const {

--- a/packages/core/src/App/Containers/trade-notifications.tsx
+++ b/packages/core/src/App/Containers/trade-notifications.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
+
 import { MobileWrapper, Money, SwipeableNotification, Text } from '@deriv/components';
-import { useStore } from '@deriv/stores';
 import { getCardLabels, getContractPath } from '@deriv/shared';
-import { localize, Localize } from '@deriv-com/translations';
+import { useStore } from '@deriv/stores';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 const TradeNotifications = observer(({ show_trade_notifications }: { show_trade_notifications?: boolean }) => {
+    const { localize } = useTranslations();
     const {
         notifications: { removeTradeNotifications, trade_notifications },
     } = useStore();

--- a/packages/core/src/Components/markers/marker-spot-label.jsx
+++ b/packages/core/src/Components/markers/marker-spot-label.jsx
@@ -1,13 +1,14 @@
+import React from 'react';
 import classNames from 'classnames';
 import { observer } from 'mobx-react-lite';
 import PropTypes from 'prop-types';
-import React from 'react';
+
 import { Text } from '@deriv/components';
 import { StandaloneClockThreeRegularIcon } from '@deriv/quill-icons';
 import { addComma, toMoment } from '@deriv/shared';
+import { Localize } from '@deriv-com/translations';
 
 import MarkerSpot from './marker-spot.jsx';
-import { localize } from '@deriv-com/translations';
 
 const MarkerSpotLabel = ({
     align_label,
@@ -21,7 +22,6 @@ const MarkerSpotLabel = ({
     status,
 }) => {
     const [show_label, setShowLabel] = React.useState(!has_hover_toggle);
-
     const handleHoverToggle = () => {
         setShowLabel(!show_label);
     };
@@ -90,7 +90,7 @@ const MarkerSpotLabel = ({
                         })}
                     >
                         <Text as='p' size='xxs'>
-                            {localize('Total profit/loss:')}
+                            <Localize i18n_default_text='Total profit/loss:' />
                         </Text>
                         <Text as='p' size='xs'>{`${parseFloat(spot_profit) > 0 ? '+' : ''}${spot_profit}`}</Text>
                     </div>

--- a/packages/core/src/Modules/Callback/AccessDeniedScreen.tsx
+++ b/packages/core/src/Modules/Callback/AccessDeniedScreen.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 import Cookies from 'js-cookie';
 
-import { Loading } from '@deriv/components';
 import { useOauth2 } from '@deriv/api';
+import { Loading } from '@deriv/components';
 import {
     BrandBrandLightDerivWordmarkHorizontal25YearsEnglishIcon as DerivLogo,
     LegacyWarningIcon,
 } from '@deriv/quill-icons';
 import { getBrandUrl } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
+import { Localize } from '@deriv-com/translations';
 import { Text } from '@deriv-com/ui';
 
 import './AccessDeniedScreen.scss';
@@ -59,24 +59,24 @@ const AccessDeniedScreen = observer(() => {
                     <>
                         <LegacyWarningIcon width={72} height={72} fill='var(--color-text-warning)' />
                         <Text as='h2' className='access-denied__title' weight='bold' align='center'>
-                            {localize("You're currently logged in as")} <br />
+                            <Localize i18n_default_text="You're currently logged in as" /> <br />
                             {email_address}
                         </Text>
                         <Text as='p' align='center' className='access-denied__description'>
-                            {localize('Would you like to continue with this')}
+                            <Localize i18n_default_text='Would you like to continue with this' />
                             <br />
-                            {localize('account or switch to a different one?')}
+                            <Localize i18n_default_text='account or switch to a different one?' />
                         </Text>
 
                         <div className='access-denied__actions'>
                             <button className='access-denied__button' onClick={continueOnClick}>
-                                {localize('Continue')}
+                                <Localize i18n_default_text='Continue' />
                             </button>
                             <button
                                 className='access-denied__button access-denied__button--switch'
                                 onClick={oAuthLogout}
                             >
-                                {localize('Switch account')}
+                                <Localize i18n_default_text='Switch account' />
                             </button>
                         </div>
                     </>

--- a/packages/core/src/Modules/Page404/Components/Page404.jsx
+++ b/packages/core/src/Modules/Page404/Components/Page404.jsx
@@ -1,21 +1,24 @@
 import React from 'react';
+
 import { PageError } from '@deriv/components';
-import { routes, getUrlBase } from '@deriv/shared';
+import { getUrlBase, routes } from '@deriv/shared';
+import { useTranslations } from '@deriv-com/translations';
 
-import { localize } from '@deriv-com/translations';
-
-const Page404 = () => (
-    <PageError
-        header={localize('We couldn’t find that page')}
-        messages={[
-            localize('You may have followed a broken link, or the page has moved to a new address.'),
-            localize('Error code: {{error_code}} page not found', { error_code: 404 }),
-        ]}
-        redirect_urls={[routes.index]}
-        redirect_labels={[localize('Return to trade')]}
-        classNameImage='page-404__image'
-        image_url={getUrlBase('/public/images/common/404.png')}
-    />
-);
+const Page404 = () => {
+    const { localize } = useTranslations();
+    return (
+        <PageError
+            header={localize("We couldn't find that page")}
+            messages={[
+                localize('You may have followed a broken link, or the page has moved to a new address.'),
+                localize('Error code: {{error_code}} page not found', { error_code: 404 }),
+            ]}
+            redirect_urls={[routes.index]}
+            redirect_labels={[localize('Return to trade')]}
+            classNameImage='page-404__image'
+            image_url={getUrlBase('/public/images/common/404.png')}
+        />
+    );
+};
 
 export default Page404;

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/account-verification-required-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/account-verification-required-modal.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+
 import { Button, Modal } from '@deriv/components';
-import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize, Localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TAccountVerificationRequiredModalProps = {
     is_visible: boolean;
@@ -12,7 +11,7 @@ type TAccountVerificationRequiredModalProps = {
 
 const AccountVerificationRequiredModal = observer(
     ({ is_visible, onConfirm }: TAccountVerificationRequiredModalProps) => {
-        const history = useHistory();
+        const { localize } = useTranslations();
         const {
             ui: { is_mobile },
         } = useStore();
@@ -22,7 +21,7 @@ const AccountVerificationRequiredModal = observer(
                 is_vertical_centered={is_mobile}
                 className='account-verification-required-modal'
                 toggleModal={onConfirm}
-                title={localize('Account verification required')}
+                title={<Localize i18n_default_text='Account verification required' />}
                 width='440px'
                 height={is_mobile ? 'auto' : '220px'}
             >

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, Modal } from '@deriv/components';
 import { redirectToLogin, redirectToSignUp } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 type TAuthorizationRequiredModal = {
     is_visible: boolean;
@@ -11,20 +11,23 @@ type TAuthorizationRequiredModal = {
     is_logged_in: boolean;
 };
 
-const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => (
-    <Modal
-        id='dt_authorization_required_modal'
-        is_open={is_visible}
-        small
-        toggleModal={toggleModal}
-        title={localize('Start trading with us')}
-    >
-        <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
-        <Modal.Footer>
-            <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
-            <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
-        </Modal.Footer>
-    </Modal>
-);
+const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => {
+    const { localize } = useTranslations();
+    return (
+        <Modal
+            id='dt_authorization_required_modal'
+            is_open={is_visible}
+            small
+            toggleModal={toggleModal}
+            title={localize('Start trading with us')}
+        >
+            <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
+            <Modal.Footer>
+                <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
+                <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
+            </Modal.Footer>
+        </Modal>
+    );
+};
 
 export default AuthorizationRequiredModal;

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/company-wide-limit-exceeded-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/company-wide-limit-exceeded-modal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+
 import { Button, Modal, StaticUrl } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
-import { localize, Localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TCompanyWideLimitExceededModal = {
     is_visible: boolean;
@@ -9,6 +10,7 @@ type TCompanyWideLimitExceededModal = {
 };
 
 const CompanyWideLimitExceededModal = observer(({ is_visible, onConfirm }: TCompanyWideLimitExceededModal) => {
+    const { localize } = useTranslations();
     const {
         ui: { is_mobile },
     } = useStore();

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/insufficient-balance-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/insufficient-balance-modal.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+
 import { Button, Modal } from '@deriv/components';
 import { getBrandUrl } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 type TInsufficientBalanceModal = RouteComponentProps & {
     is_virtual?: boolean;
@@ -17,6 +18,7 @@ const InsufficientBalanceModal = observer(
         const {
             ui: { is_mobile },
         } = useStore();
+        const { localize } = useTranslations();
         return (
             <Modal
                 id='dt_insufficient_balance_modal'

--- a/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/services-error-modal.tsx
+++ b/packages/reports/src/Components/Elements/Modals/ServicesErrorModal/services-error-modal.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+
 import { Button, Modal } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
-import { getTitle } from './constants';
-import AuthorizationRequiredModal from './authorization-required-modal';
-import InsufficientBalanceModal from './insufficient-balance-modal';
-import CompanyWideLimitExceededModal from './company-wide-limit-exceeded-modal';
+import { useTranslations } from '@deriv-com/translations';
+
 import AccountVerificationRequiredModal from './account-verification-required-modal';
+import AuthorizationRequiredModal from './authorization-required-modal';
+import CompanyWideLimitExceededModal from './company-wide-limit-exceeded-modal';
+import { getTitle } from './constants';
+import InsufficientBalanceModal from './insufficient-balance-modal';
 
 type TServicesError = {
     code?: string;
@@ -29,6 +31,7 @@ const ServicesErrorModal = ({
     services_error,
 }: TPropServicesErrorModel) => {
     const { code, message, type } = services_error;
+    const { localize } = useTranslations();
 
     if (!code || !message) return <React.Fragment />;
     switch (code) {

--- a/packages/reports/src/Components/Errors/error-component.tsx
+++ b/packages/reports/src/Components/Errors/error-component.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { Dialog, PageErrorContainer } from '@deriv/components';
 import { routes } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
+
 import { TErrorComponent } from 'Types';
 
 const ErrorComponent = ({
@@ -12,6 +14,7 @@ const ErrorComponent = ({
     redirectOnClick,
     should_show_refresh = true,
 }: Partial<TErrorComponent>) => {
+    const { localize } = useTranslations();
     const refresh_message = should_show_refresh ? localize('Please refresh this page to continue.') : '';
 
     if (is_dialog) {

--- a/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar-mobile.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar-mobile.tsx
@@ -1,9 +1,11 @@
-import classNames from 'classnames';
 import React from 'react';
+import classNames from 'classnames';
+
 import { Button, DatePicker, InputField, MobileDialog, Text } from '@deriv/components';
 import { LegacyCalendar1pxIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
 import { toMoment } from '@deriv/shared';
+import { useTranslations } from '@deriv-com/translations';
+
 import { TInputDateRange } from 'Types';
 
 type TDatePickerOnChangeParams = Parameters<React.ComponentProps<typeof DatePicker>['onChange']>[0];
@@ -69,6 +71,7 @@ const CompositeCalendarMobile = React.memo(
         from,
         to,
     }: TCompositeCalendarMobile) => {
+        const { localize } = useTranslations();
         const date_range = input_date_range || duration_list?.find(range => range.value === 'all_time');
 
         const [from_date, setFrom] = React.useState(from ? toMoment(from).format('YYYY-MM-DD') : undefined);

--- a/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import Loadable from 'react-loadable';
-import { useDevice } from '@deriv-com/ui';
+import moment from 'moment';
+
 import { InputField, useOnClickOutside } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
 import { daysFromTodayTo, toMoment } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+import { useDevice } from '@deriv-com/ui';
+
+import CalendarIcon from './calendar-icon';
 import CompositeCalendarMobile from './composite-calendar-mobile';
 import SideList from './side-list';
-import CalendarIcon from './calendar-icon';
 import TwoMonthPicker from './two-month-picker';
-import moment from 'moment';
-import { observer, useStore } from '@deriv/stores';
 
 type TCompositeCalendar = {
     onChange: (values: { to?: moment.Moment; from?: moment.Moment; is_batch?: boolean }) => void;
@@ -33,6 +35,7 @@ const TwoMonthPickerLoadable = Loadable<TTwoMonthPickerLoadable, typeof TwoMonth
 });
 
 const CompositeCalendar = observer((props: TCompositeCalendar) => {
+    const { localize } = useTranslations();
     const { ui } = useStore();
     const { current_focus, setCurrentFocus } = ui;
     const { onChange, to, from } = props;

--- a/packages/reports/src/Components/filter-component.tsx
+++ b/packages/reports/src/Components/filter-component.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+
 import { FilterDropdown } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
-import CompositeCalendar from './Form/CompositeCalendar';
 import { observer } from '@deriv/stores';
+import { useTranslations } from '@deriv-com/translations';
+
 import { useReportsStore } from 'Stores/useReportsStores';
 
+import CompositeCalendar from './Form/CompositeCalendar';
+
 const FilterComponent = observer(() => {
+    const { localize } = useTranslations();
     const { statement } = useReportsStore();
     const { action_type, date_from, date_to, handleFilterChange, handleDateChange } = statement;
 

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -1,17 +1,20 @@
-import classNames from 'classnames';
 import React from 'react';
-import { ArrowIndicator, Label, Money, ContractCard, ContractCardSell, Popover } from '@deriv/components';
-import { getCurrencyDisplayCode, getTotalProfit, getGrowthRatePercentage, getCardLabels } from '@deriv/shared';
-import { localize, Localize } from '@deriv-com/translations';
-import ProgressSliderStream from '../Containers/progress-slider-stream';
+import classNames from 'classnames';
+import moment from 'moment';
+
+import { ArrowIndicator, ContractCard, ContractCardSell, Label, Money, Popover } from '@deriv/components';
+import { getCardLabels, getCurrencyDisplayCode, getGrowthRatePercentage, getTotalProfit } from '@deriv/shared';
+import { useStore } from '@deriv/stores';
+import { Localize } from '@deriv-com/translations';
+
 import { TCellContentProps, THeaderProps } from 'Types';
-import { getProfitOrLoss } from '../Helpers/profit-loss';
+
+import CurrencyWrapper from '../Components/currency-wrapper';
 import IndicativeCell from '../Components/indicative-cell';
 import MarketSymbolIconRow from '../Components/market-symbol-icon-row';
 import ProfitLossCell from '../Components/profit-loss-cell';
-import CurrencyWrapper from '../Components/currency-wrapper';
-import { useStore } from '@deriv/stores';
-import moment from 'moment';
+import ProgressSliderStream from '../Containers/progress-slider-stream';
+import { getProfitOrLoss } from '../Helpers/profit-loss';
 
 type TPortfolioStore = ReturnType<typeof useStore>['portfolio'];
 
@@ -51,7 +54,7 @@ type TMultiplierOpenPositionstemplateProps = Pick<
 export const getStatementTableColumnsTemplate = (currency: string, isDesktop: boolean) => [
     {
         key: 'icon',
-        title: isDesktop ? localize('Type') : '',
+        title: isDesktop ? <Localize i18n_default_text='Type' /> : '',
         col_index: 'icon',
         renderCellContent: ({ passthrough, row_obj }: TCellContentProps) => {
             const icon = passthrough.isTopUp(row_obj) ? 'icCashierTopUp' : null;
@@ -59,13 +62,18 @@ export const getStatementTableColumnsTemplate = (currency: string, isDesktop: bo
         },
     },
     {
-        title: localize('Ref. ID'),
+        title: <Localize i18n_default_text='Ref. ID' />,
         col_index: 'refid',
         renderCellContent: ({ cell_value, row_obj }: TCellContentProps) => {
             return (
                 <Popover
                     alignment={'top'}
-                    message={localize('Transaction performed by (App ID: {{app_id}})', { app_id: row_obj.app_id })}
+                    message={
+                        <Localize
+                            i18n_default_text='Transaction performed by (App ID: {{app_id}})'
+                            values={{ app_id: row_obj.app_id }}
+                        />
+                    }
                 >
                     {cell_value}
                 </Popover>
@@ -73,12 +81,12 @@ export const getStatementTableColumnsTemplate = (currency: string, isDesktop: bo
         },
     },
     {
-        title: localize('Currency'),
+        title: <Localize i18n_default_text='Currency' />,
         col_index: 'currency',
         renderCellContent: () => <CurrencyWrapper currency={getCurrencyDisplayCode(currency)} />,
     },
     {
-        title: localize('Transaction time'),
+        title: <Localize i18n_default_text='Transaction time' />,
         col_index: 'date',
         renderCellContent: ({ cell_value }: TCellContentProps) => {
             return <span>{cell_value} GMT</span>;
@@ -86,16 +94,16 @@ export const getStatementTableColumnsTemplate = (currency: string, isDesktop: bo
     },
     {
         key: 'mode',
-        title: localize('Transaction'),
+        title: <Localize i18n_default_text='Transaction' />,
         col_index: 'action_type',
         renderCellContent: ({ cell_value, passthrough, row_obj }: TCellContentProps) => (
             <Label mode={getModeFromValue(cell_value)}>
-                {(passthrough.isTopUp(row_obj) && localize('Top up')) || row_obj.action}
+                {(passthrough.isTopUp(row_obj) && <Localize i18n_default_text='Top up' />) || row_obj.action}
             </Label>
         ),
     },
     {
-        title: localize('Credit/Debit'),
+        title: <Localize i18n_default_text='Credit/Debit' />,
         col_index: 'amount',
         renderCellContent: ({ cell_value }: TCellContentProps) => (
             <div className={`amount--${getProfitOrLoss(cell_value)}`}>
@@ -104,7 +112,7 @@ export const getStatementTableColumnsTemplate = (currency: string, isDesktop: bo
         ),
     },
     {
-        title: localize('Balance'),
+        title: <Localize i18n_default_text='Balance' />,
         col_index: 'balance',
         renderCellContent: ({ cell_value }: TCellContentProps) => (
             <Money amount={cell_value.replace(/[,]+/g, '')} currency={currency} />
@@ -114,27 +122,32 @@ export const getStatementTableColumnsTemplate = (currency: string, isDesktop: bo
 export const getProfitTableColumnsTemplate = (currency: string, items_count: number, isDesktop: boolean) => [
     {
         key: 'icon',
-        title: isDesktop ? localize('Type') : '',
+        title: isDesktop ? <Localize i18n_default_text='Type' /> : '',
         col_index: 'action_type',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
             if (is_footer) {
-                return localize('Profit/loss on the last {{item_count}} contracts', { item_count: items_count });
+                return (
+                    <Localize
+                        i18n_default_text='Profit/loss on the last {{item_count}} contracts'
+                        values={{ item_count: items_count }}
+                    />
+                );
             }
             return <MarketSymbolIconRow key={row_obj.transaction_id} payload={row_obj} />;
         },
     },
     {
-        title: localize('Ref. ID'),
+        title: <Localize i18n_default_text='Ref. ID' />,
         col_index: 'transaction_id',
     },
     {
-        title: localize('Currency'),
+        title: <Localize i18n_default_text='Currency' />,
         col_index: 'currency',
         renderCellContent: ({ is_footer }: TCellContentProps) =>
             is_footer ? '' : <CurrencyWrapper currency={getCurrencyDisplayCode(currency)} />,
     },
     {
-        title: localize('Buy time'),
+        title: <Localize i18n_default_text='Buy time' />,
         col_index: 'purchase_time',
         renderCellContent: ({ cell_value, is_footer }: TCellContentProps) => {
             if (is_footer) return '';
@@ -142,7 +155,7 @@ export const getProfitTableColumnsTemplate = (currency: string, items_count: num
         },
     },
     {
-        title: localize('Stake'),
+        title: <Localize i18n_default_text='Stake' />,
         col_index: 'buy_price',
         renderCellContent: ({ cell_value, is_footer }: TCellContentProps) => {
             if (is_footer) return '';
@@ -151,7 +164,7 @@ export const getProfitTableColumnsTemplate = (currency: string, items_count: num
         },
     },
     {
-        title: localize('Sell time'),
+        title: <Localize i18n_default_text='Sell time' />,
         col_index: 'sell_time',
         renderHeader: ({ title }: THeaderProps) => <span>{title}</span>,
         renderCellContent: ({ cell_value, is_footer }: TCellContentProps) => {
@@ -160,7 +173,7 @@ export const getProfitTableColumnsTemplate = (currency: string, items_count: num
         },
     },
     {
-        title: localize('Contract value'),
+        title: <Localize i18n_default_text='Contract value' />,
         col_index: 'sell_price',
         renderCellContent: ({ cell_value, is_footer }: TCellContentProps) => {
             if (is_footer) return '';
@@ -169,7 +182,7 @@ export const getProfitTableColumnsTemplate = (currency: string, items_count: num
         },
     },
     {
-        title: localize('Total profit/loss'),
+        title: <Localize i18n_default_text='Total profit/loss' />,
         col_index: 'profit_loss',
         renderCellContent: ({ cell_value }: TCellContentProps) => (
             <ProfitLossCell value={cell_value}>
@@ -181,10 +194,10 @@ export const getProfitTableColumnsTemplate = (currency: string, items_count: num
 export const getOpenPositionsColumnsTemplate = (currency: string, isDesktop: boolean) => [
     {
         key: 'icon',
-        title: isDesktop ? localize('Type') : '',
+        title: isDesktop ? <Localize i18n_default_text='Type' /> : '',
         col_index: 'type',
         renderCellContent: ({ row_obj, is_footer, is_vanilla, is_turbos }: TCellContentProps) => {
-            if (is_footer) return localize('Total');
+            if (is_footer) return <Localize i18n_default_text='Total' />;
 
             return (
                 <MarketSymbolIconRow
@@ -196,32 +209,34 @@ export const getOpenPositionsColumnsTemplate = (currency: string, isDesktop: boo
         },
     },
     {
-        title: localize('Ref. ID'),
+        title: <Localize i18n_default_text='Ref. ID' />,
         col_index: 'reference',
     },
     {
-        title: localize('Currency'),
+        title: <Localize i18n_default_text='Currency' />,
         col_index: 'currency',
         renderCellContent: ({ row_obj }: TCellContentProps) => (
             <CurrencyWrapper currency={getCurrencyDisplayCode(row_obj.contract_info?.currency)} />
         ),
     },
     {
-        title: localize('Stake'),
+        title: <Localize i18n_default_text='Stake' />,
         col_index: 'purchase',
         renderCellContent: ({ cell_value }: TCellContentProps) => <Money amount={cell_value} currency={currency} />,
     },
     {
-        title: localize('Potential payout'),
+        title: <Localize i18n_default_text='Potential payout' />,
         col_index: 'payout',
-        renderHeader: ({ title, is_vanilla }: THeaderProps) => <span>{is_vanilla ? localize('Strike') : title}</span>,
+        renderHeader: ({ title, is_vanilla }: THeaderProps) => (
+            <span>{is_vanilla ? <Localize i18n_default_text='Strike' /> : title}</span>
+        ),
         renderCellContent: ({ cell_value, row_obj, is_vanilla }: TCellContentProps) => {
             const non_vanilla_payout = cell_value ? <Money amount={cell_value} currency={currency} /> : <span>-</span>;
             return is_vanilla ? row_obj.barrier?.toFixed(2) : non_vanilla_payout;
         },
     },
     {
-        title: localize('Total profit/loss'),
+        title: <Localize i18n_default_text='Total profit/loss' />,
         col_index: 'profit',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             const { profit_loss, contract_info } = row_obj ?? {};
@@ -242,7 +257,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string, isDesktop: boo
         },
     },
     {
-        title: localize('Contract value'),
+        title: <Localize i18n_default_text='Contract value' />,
         col_index: 'indicative',
         renderCellContent: ({ cell_value, row_obj, is_footer }: TCellContentProps) => {
             const { profit_loss, contract_info } = row_obj ?? {};
@@ -261,7 +276,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string, isDesktop: boo
         },
     },
     {
-        title: localize('Remaining time'),
+        title: <Localize i18n_default_text='Remaining time' />,
         col_index: 'id',
         renderCellContent: ({ row_obj }: TCellContentProps) => (
             <ProgressSliderStream contract_info={row_obj.contract_info} />
@@ -278,10 +293,10 @@ export const getMultiplierOpenPositionsColumnsTemplate = ({
     isDesktop,
 }: TMultiplierOpenPositionstemplateProps) => [
     {
-        title: isDesktop ? localize('Type') : '',
+        title: isDesktop ? <Localize i18n_default_text='Type' /> : '',
         col_index: 'type',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
-            if (is_footer) return localize('Total');
+            if (is_footer) return <Localize i18n_default_text='Total' />;
 
             return (
                 <MarketSymbolIconRow key={row_obj.id} payload={row_obj.contract_info} should_show_multiplier={false} />
@@ -289,20 +304,20 @@ export const getMultiplierOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Multiplier'),
+        title: <Localize i18n_default_text='Multiplier' />,
         col_index: 'multiplier',
         renderCellContent: ({ row_obj }: TCellContentProps) =>
             row_obj.contract_info && row_obj.contract_info.multiplier ? `x${row_obj.contract_info.multiplier}` : '',
     },
     {
-        title: localize('Currency'),
+        title: <Localize i18n_default_text='Currency' />,
         col_index: 'currency',
         renderCellContent: ({ row_obj }: TCellContentProps) => (
             <CurrencyWrapper currency={getCurrencyDisplayCode(row_obj.contract_info?.currency)} />
         ),
     },
     {
-        title: localize('Contract cost'),
+        title: <Localize i18n_default_text='Contract cost' />,
         col_index: 'buy_price',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             if (row_obj.contract_info) {
@@ -313,7 +328,7 @@ export const getMultiplierOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Deal cancel. fee'),
+        title: <Localize i18n_default_text='Deal cancel. fee' />,
         col_index: 'cancellation',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             if (!row_obj.contract_info) return '-';
@@ -363,7 +378,7 @@ export const getMultiplierOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Contract value'),
+        title: <Localize i18n_default_text='Contract value' />,
         col_index: 'bid_price',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
             if (is_footer) {
@@ -411,7 +426,7 @@ export const getMultiplierOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Action'),
+        title: <Localize i18n_default_text='Action' />,
         col_index: 'action',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
             if (is_footer) {
@@ -445,10 +460,10 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
     isDesktop,
 }: TAccumulatorOpenPositionstemplateProps) => [
     {
-        title: isDesktop ? localize('Type') : '',
+        title: isDesktop ? <Localize i18n_default_text='Type' /> : '',
         col_index: 'type',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
-            if (is_footer) return localize('Total');
+            if (is_footer) return <Localize i18n_default_text='Total' />;
 
             return (
                 <MarketSymbolIconRow
@@ -461,7 +476,7 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Growth rate'),
+        title: <Localize i18n_default_text='Growth rate' />,
         col_index: 'growth_rate',
         renderCellContent: ({ row_obj }: TCellContentProps) =>
             row_obj.contract_info && row_obj.contract_info.growth_rate
@@ -469,14 +484,14 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
                 : '',
     },
     {
-        title: localize('Currency'),
+        title: <Localize i18n_default_text='Currency' />,
         col_index: 'currency',
         renderCellContent: ({ row_obj }: TCellContentProps) => (
             <CurrencyWrapper currency={getCurrencyDisplayCode(row_obj.contract_info?.currency)} />
         ),
     },
     {
-        title: localize('Stake'),
+        title: <Localize i18n_default_text='Stake' />,
         col_index: isDesktop ? 'buy_price' : 'purchase',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             if (row_obj.contract_info) {
@@ -486,7 +501,7 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Take profit'),
+        title: <Localize i18n_default_text='Take profit' />,
         col_index: 'limit_order',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             const { take_profit } = row_obj.contract_info?.limit_order || {};
@@ -502,7 +517,7 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Contract value'),
+        title: <Localize i18n_default_text='Contract value' />,
         col_index: 'bid_price',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             if (!row_obj.contract_info || !row_obj.contract_info.bid_price) return '-';
@@ -522,7 +537,7 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Total profit/loss'),
+        title: <Localize i18n_default_text='Total profit/loss' />,
         col_index: 'profit',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             if (!row_obj.contract_info || !row_obj.contract_info.profit) return null;
@@ -542,7 +557,7 @@ export const getAccumulatorOpenPositionsColumnsTemplate = ({
         },
     },
     {
-        title: localize('Action'),
+        title: <Localize i18n_default_text='Action' />,
         col_index: 'action',
         renderCellContent: ({ row_obj, is_footer }: TCellContentProps) => {
             if (is_footer) {

--- a/packages/reports/src/Constants/routes-config.tsx
+++ b/packages/reports/src/Constants/routes-config.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { routes, makeLazyLoader, moduleLoader } from '@deriv/shared';
+
 import { Loading } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
 import {
-    LegacyReportsIcon,
     LegacyOpenPositionIcon,
     LegacyProfitTableIcon,
+    LegacyReportsIcon,
     LegacyStatementIcon,
 } from '@deriv/quill-icons';
+import { makeLazyLoader, moduleLoader, routes } from '@deriv/shared';
+import { Localize } from '@deriv-com/translations';
+
 import type { TRoute, TRouteConfig } from 'Types';
 
 const Page404 = React.lazy(() => import(/* webpackChunkName: "404" */ 'Modules/Page404'));
@@ -24,26 +26,26 @@ const initRoutesConfig = (): TRouteConfig[] => {
             path: routes.reports,
             component: lazyLoadReportComponent('Reports'),
             is_authenticated: true,
-            getTitle: () => localize('Reports'),
+            getTitle: () => <Localize i18n_default_text='Reports' />,
             icon_component: <LegacyReportsIcon iconSize='xs' />,
             routes: [
                 {
                     path: routes.positions,
                     component: lazyLoadReportComponent('OpenPositions'),
-                    getTitle: () => localize('Open positions'),
+                    getTitle: () => <Localize i18n_default_text='Open positions' />,
                     icon_component: <LegacyOpenPositionIcon iconSize='xs' />,
                     default: true,
                 },
                 {
                     path: routes.profit,
                     component: lazyLoadReportComponent('ProfitTable'),
-                    getTitle: () => localize('Trade table'),
+                    getTitle: () => <Localize i18n_default_text='Trade table' />,
                     icon_component: <LegacyProfitTableIcon iconSize='xs' />,
                 },
                 {
                     path: routes.statement,
                     component: lazyLoadReportComponent('Statement'),
-                    getTitle: () => localize('Statement'),
+                    getTitle: () => <Localize i18n_default_text='Statement' />,
                     icon_component: <LegacyStatementIcon iconSize='xs' />,
                 },
             ],
@@ -54,7 +56,7 @@ const initRoutesConfig = (): TRouteConfig[] => {
 let routesConfig: TRouteConfig[];
 
 // For default page route if page/path is not found, must be kept at the end of routes_config array
-const route_default: TRoute = { component: Page404, getTitle: () => localize('Error 404') };
+const route_default: TRoute = { component: Page404, getTitle: () => <Localize i18n_default_text='Error 404' /> };
 
 const getRoutesConfig = (): TRouteConfig[] => {
     if (!routesConfig) {

--- a/packages/reports/src/Containers/open-positions.tsx
+++ b/packages/reports/src/Containers/open-positions.tsx
@@ -11,8 +11,8 @@ import {
     toMoment,
 } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
 import { Analytics } from '@deriv-com/analytics';
+import { useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import {
@@ -151,6 +151,7 @@ const getOpenPositionsTotals = (
 };
 
 const OpenPositions = observer(({ component_icon, ...props }: TOpenPositions) => {
+    const { localize } = useTranslations();
     const { portfolio, client, ui, common, contract_trade } = useStore();
     const {
         active_positions,

--- a/packages/reports/src/Containers/profit-table.tsx
+++ b/packages/reports/src/Containers/profit-table.tsx
@@ -1,20 +1,23 @@
-import classNames from 'classnames';
 import React from 'react';
 import { withRouter } from 'react-router';
+import classNames from 'classnames';
+
 import { DataList, DataTable, usePrevious } from '@deriv/components';
 import { extractInfoFromShortcode, formatDate, getContractPath, getUnsupportedContracts } from '@deriv/shared';
-import { localize, Localize } from '@deriv-com/translations';
+import { observer, useStore } from '@deriv/stores';
 import { Analytics } from '@deriv-com/analytics';
-import { ReportsTableRowLoader } from '../Components/Elements/ContentLoader';
-import CompositeCalendar from '../Components/Form/CompositeCalendar';
+import { Localize, useTranslations } from '@deriv-com/translations';
+import { useDevice } from '@deriv-com/ui';
+
+import { getProfitTableColumnsTemplate } from 'Constants/data-table-constants';
+import { useReportsStore } from 'Stores/useReportsStores';
 import { TUnsupportedContractType } from 'Types';
+
+import { ReportsTableRowLoader } from '../Components/Elements/ContentLoader';
 import EmptyTradeHistoryMessage from '../Components/empty-trade-history-message';
+import CompositeCalendar from '../Components/Form/CompositeCalendar';
 import PlaceholderComponent from '../Components/placeholder-component';
 import { ReportsMeta } from '../Components/reports-meta';
-import { getProfitTableColumnsTemplate } from 'Constants/data-table-constants';
-import { observer, useStore } from '@deriv/stores';
-import { useReportsStore } from 'Stores/useReportsStores';
-import { useDevice } from '@deriv-com/ui';
 
 type TProfitTable = {
     component_icon: React.ReactElement;
@@ -43,6 +46,7 @@ export const getRowAction = (row_obj: { [key: string]: unknown }) => {
 };
 
 const ProfitTable = observer(({ component_icon }: TProfitTable) => {
+    const { localize } = useTranslations();
     const { client } = useStore();
     const { profit_table } = useReportsStore();
     const { currency } = client;

--- a/packages/reports/src/Containers/reports.tsx
+++ b/packages/reports/src/Containers/reports.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
+
 import { Div100vhContainer, FadeWrapper, Loading, PageOverlay, SelectNative, VerticalTab } from '@deriv/components';
 import { getSelectedRoute } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
 import { observer, useStore } from '@deriv/stores';
 import { Analytics } from '@deriv-com/analytics';
+import { useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
+
 import { TRoute } from 'Types';
+
 import 'Sass/app/modules/reports.scss';
 
 type TList = {
@@ -24,6 +27,7 @@ type TReports = {
 };
 
 const Reports = observer(({ history, location, routes }: TReports) => {
+    const { localize } = useTranslations();
     const { client, common, ui } = useStore();
 
     const { is_logged_in, is_logging_in } = client;

--- a/packages/reports/src/Containers/statement.tsx
+++ b/packages/reports/src/Containers/statement.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { useDevice } from '@deriv-com/ui';
-import { DataList, DataTable, Text, Clipboard, usePrevious } from '@deriv/components';
+
+import { Clipboard, DataList, DataTable, Text, usePrevious } from '@deriv/components';
+import { TSource } from '@deriv/components/src/components/data-table/table-row';
+import { TRow } from '@deriv/components/src/components/types/common.types';
 import {
     capitalizeFirstLetter,
     extractInfoFromShortcode,
@@ -9,19 +11,20 @@ import {
     getContractPath,
     getUnsupportedContracts,
 } from '@deriv/shared';
-import { localize, Localize } from '@deriv-com/translations';
-import { Analytics } from '@deriv-com/analytics';
-import { ReportsTableRowLoader } from '../Components/Elements/ContentLoader';
-import { getStatementTableColumnsTemplate } from '../Constants/data-table-constants';
-import PlaceholderComponent from '../Components/placeholder-component';
-import FilterComponent from '../Components/filter-component';
-import { ReportsMeta } from '../Components/reports-meta';
-import EmptyTradeHistoryMessage from '../Components/empty-trade-history-message';
 import { observer, useStore } from '@deriv/stores';
+import { Analytics } from '@deriv-com/analytics';
+import { Localize, useTranslations } from '@deriv-com/translations';
+import { useDevice } from '@deriv-com/ui';
+
 import { useReportsStore } from 'Stores/useReportsStores';
 import { TUnsupportedContractType } from 'Types';
-import { TSource } from '@deriv/components/src/components/data-table/table-row';
-import { TRow } from '@deriv/components/src/components/types/common.types';
+
+import { ReportsTableRowLoader } from '../Components/Elements/ContentLoader';
+import EmptyTradeHistoryMessage from '../Components/empty-trade-history-message';
+import FilterComponent from '../Components/filter-component';
+import PlaceholderComponent from '../Components/placeholder-component';
+import { ReportsMeta } from '../Components/reports-meta';
+import { getStatementTableColumnsTemplate } from '../Constants/data-table-constants';
 
 type TGetStatementTableColumnsTemplate = ReturnType<typeof getStatementTableColumnsTemplate>;
 type TColIndex = 'icon' | 'refid' | 'currency' | 'date' | 'action_type' | 'amount' | 'balance';
@@ -124,6 +127,7 @@ export const getRowAction = (row_obj: TSource | TRow): TAction => {
 };
 
 const Statement = observer(({ component_icon }: TStatement) => {
+    const { localize } = useTranslations();
     const { client, common } = useStore();
     const { current_language } = common;
     const { statement } = useReportsStore();

--- a/packages/reports/src/Modules/Page404/Components/Page404.tsx
+++ b/packages/reports/src/Modules/Page404/Components/Page404.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
+
 import { PageError } from '@deriv/components';
-import { routes, getUrlBase } from '@deriv/shared';
+import { getUrlBase, routes } from '@deriv/shared';
+import { useTranslations } from '@deriv-com/translations';
 
-import { localize } from '@deriv-com/translations';
-
-const Page404 = () => (
-    <PageError
-        header={localize('We couldn’t find that page')}
-        messages={[
-            localize('You may have followed a broken link, or the page has moved to a new address.'),
-            localize('Error code: {{error_code}} page not found', { error_code: 404 }),
-        ]}
-        redirect_urls={[routes.index]}
-        redirect_labels={[localize('Return to trade')]}
-        classNameImage='page-404__image'
-        image_url={getUrlBase('/public/images/common/404.png')}
-    />
-);
+const Page404 = () => {
+    const { localize } = useTranslations();
+    return (
+        <PageError
+            header={localize('We couldn’t find that page')}
+            messages={[
+                localize('You may have followed a broken link, or the page has moved to a new address.'),
+                localize('Error code: {{error_code}} page not found', { error_code: 404 }),
+            ]}
+            redirect_urls={[routes.index]}
+            redirect_labels={[localize('Return to trade')]}
+            classNameImage='page-404__image'
+            image_url={getUrlBase('/public/images/common/404.png')}
+        />
+    );
+};
 
 export default Page404;

--- a/packages/reports/src/Types/common-prop.type.ts
+++ b/packages/reports/src/Types/common-prop.type.ts
@@ -26,7 +26,7 @@ export type TRoute = {
     path?: string;
     component: React.ComponentType | typeof Redirect;
     is_authenticated?: boolean;
-    getTitle: () => string;
+    getTitle: () => string | React.ReactElement;
     icon_component?: React.ReactElement;
     routes?: TRoute[];
     default?: boolean;

--- a/packages/shared/src/utils/constants/phone-number-verification.tsx
+++ b/packages/shared/src/utils/constants/phone-number-verification.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import { localize, Localize } from '@deriv-com/translations';
+
 import { Chat } from '@deriv/utils';
+import { Localize } from '@deriv-com/translations';
 
 export const VERIFICATION_SERVICES = {
     SMS: 'sms',
@@ -10,8 +11,8 @@ export const VERIFICATION_SERVICES = {
 
 export const getCarriers = () =>
     ({
-        SMS: localize('SMS'),
-        WHATSAPP: localize('WhatsApp'),
+        SMS: <Localize i18n_default_text='SMS' />,
+        WHATSAPP: <Localize i18n_default_text='WhatsApp' />,
     }) as const;
 
 export const shouldShowPhoneVerificationNotification = (nextAttemptTimestamp: number, current_time: dayjs.Dayjs) => {

--- a/packages/shared/src/utils/constants/withdrawal-limits-details.tsx
+++ b/packages/shared/src/utils/constants/withdrawal-limits-details.tsx
@@ -1,23 +1,29 @@
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 export const getWithdrawalTitle = (withdrawal_type: string, num_of_days?: number) => {
     const titles = {
-        lifetime_limit: localize('Total withdrawal allowed (Lifetime)'),
-        num_of_days_limit: localize('Total withdrawal allowed ({{num_of_days}} days).', { num_of_days }),
-        withdrawal_since_inception_monetary: localize('Total withdrawn (Lifetime)'),
-        withdrawal_for_x_days_monetary: localize('Total withdrawn ({{num_of_days}} days)', { num_of_days }),
-        remainder: localize('Maximum withdrawal remaining'),
+        lifetime_limit: <Localize i18n_default_text='Total withdrawal allowed (Lifetime)' />,
+        num_of_days_limit: (
+            <Localize i18n_default_text='Total withdrawal allowed ({{num_of_days}} days).' values={{ num_of_days }} />
+        ),
+        withdrawal_since_inception_monetary: <Localize i18n_default_text='Total withdrawn (Lifetime)' />,
+        withdrawal_for_x_days_monetary: (
+            <Localize i18n_default_text='Total withdrawn ({{num_of_days}} days)' values={{ num_of_days }} />
+        ),
+        remainder: <Localize i18n_default_text='Maximum withdrawal remaining' />,
     };
     return titles[withdrawal_type as keyof typeof titles] || null;
 };
 
 export const getWithdrawalInfoMessage = (withdrawal_type: string) => {
     const messages = {
-        lifetime_limit: localize('Total amount you can withdraw over the life of this account.'),
-        num_of_days_limit: localize('Total amount you can withdraw over this period.'),
-        withdrawal_since_inception_monetary: localize('Total amount withdrawn since account opening.'),
-        withdrawal_for_x_days_monetary: localize('Total amount withdrawn over this period.'),
-        remainder: localize('Maximum funds available for withdrawal.'),
+        lifetime_limit: <Localize i18n_default_text='Total amount you can withdraw over the life of this account.' />,
+        num_of_days_limit: <Localize i18n_default_text='Total amount you can withdraw over this period.' />,
+        withdrawal_since_inception_monetary: (
+            <Localize i18n_default_text='Total amount withdrawn since account opening.' />
+        ),
+        withdrawal_for_x_days_monetary: <Localize i18n_default_text='Total amount withdrawn over this period.' />,
+        remainder: <Localize i18n_default_text='Maximum funds available for withdrawal.' />,
     };
     return messages[withdrawal_type as keyof typeof messages];
 };

--- a/packages/shared/src/utils/helpers/chart-notifications.tsx
+++ b/packages/shared/src/utils/helpers/chart-notifications.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { localize, Localize } from '@deriv-com/translations';
+
+import { Localize } from '@deriv-com/translations';
 
 export const switch_to_tick_chart = {
     key: 'switch_to_tick_chart',
-    header: localize('This chart display is not ideal for tick contracts'),
+    header: <Localize i18n_default_text='This chart display is not ideal for tick contracts' />,
     message: <Localize i18n_default_text='Please change the chart duration to tick for a better trading experience.' />,
     type: 'info',
 };

--- a/packages/shared/src/utils/helpers/portfolio-notifications.tsx
+++ b/packages/shared/src/utils/helpers/portfolio-notifications.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { localize, Localize } from '@deriv-com/translations';
+
+import { Localize } from '@deriv-com/translations';
 
 export const contractSold = (currency: string, sold_for: number | string, Money: React.ElementType) => ({
     key: 'contract_sold',
-    header: localize('Contract sold'),
+    header: <Localize i18n_default_text='Contract sold' />,
     message: (
         <Localize
             i18n_default_text='Contract was sold for <0 />.'
@@ -18,7 +19,7 @@ export const contractSold = (currency: string, sold_for: number | string, Money:
 
 export const contractCancelled = () => ({
     key: 'contract_sold',
-    header: localize('Contract cancelled'),
+    header: <Localize i18n_default_text='Contract cancelled' />,
     message: (
         <Localize
             i18n_default_text='Contract was cancelled.'

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-audit.tsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-audit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Tabs } from '@deriv/components';
 import { TContractInfo, TContractStore, WS } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -43,6 +43,7 @@ const ContractAudit = ({
 }: TContractAudit) => {
     const { contract_id, currency } = props.contract_info;
     const [update_history, setUpdateHistory] = React.useState<TContractUpdateHistory>([]);
+    const { localize } = useTranslations();
 
     const getSortedUpdateHistory = (history: TContractUpdateHistory) =>
         history.sort((a, b) => Number(b?.order_date) - Number(a?.order_date));

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.tsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.tsx
@@ -3,19 +3,19 @@ import classNames from 'classnames';
 
 import { Money, Text, ThemedScrollbars } from '@deriv/components';
 import {
-    LegacyIdIcon,
-    LegacyCommissionIcon,
-    LegacyDealCancellationIcon,
-    LegacyTimeIcon,
+    IllustrativePayoutIcon,
     LegacyBarrierIcon,
     LegacyBarrierResetIcon,
-    LegacyResetIcon,
-    LegacyTargetIcon,
-    IllustrativePayoutIcon,
-    LegacyStartTimeIcon,
+    LegacyCommissionIcon,
+    LegacyDealCancellationIcon,
     LegacyEntrySpotIcon,
     LegacyExitSpotIcon,
     LegacyExitTimeIcon,
+    LegacyIdIcon,
+    LegacyResetIcon,
+    LegacyStartTimeIcon,
+    LegacyTargetIcon,
+    LegacyTimeIcon,
 } from '@deriv/quill-icons';
 import {
     addComma,
@@ -41,8 +41,8 @@ import {
     TContractInfo,
     toGMTFormat,
 } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { Analytics } from '@deriv-com/analytics';
+import { Localize, useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import { getBarrierLabel, getBarrierValue, isDigitType } from 'App/Components/Elements/PositionsDrawer/helpers';
@@ -100,6 +100,7 @@ const ContractDetails = ({
         underlying,
     } = contract_info;
     const { isMobile } = useDevice();
+    const { localize } = useTranslations();
 
     // Backward compatibility: fallback to old field names
     const actual_entry_spot = entry_spot ?? entry_spot_display_value;

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-history.tsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-history.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Money, Text, ThemedScrollbars } from '@deriv/components';
 import { DerivLightEmptyCardboardBoxIcon } from '@deriv/quill-icons';
 import { isMobile, TContractStore } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import ContractAuditItem from './contract-audit-item';
 
@@ -16,9 +16,11 @@ const ContractHistory = ({ currency, history = [] }: TContractHistory) => {
         return (
             <div className='contract-audit__empty'>
                 <DerivLightEmptyCardboardBoxIcon width={48} height={48} fill='var(--color-text-secondary)' />
-                <h4 className='contract-audit__empty-header'>{localize('No history')}</h4>
+                <h4 className='contract-audit__empty-header'>
+                    <Localize i18n_default_text='No history' />
+                </h4>
                 <Text align='center' line_height='s' color='less-prominent' size='xxs'>
-                    {localize('You have yet to update either take profit or stop loss')}
+                    <Localize i18n_default_text='You have yet to update either take profit or stop loss' />
                 </Text>
             </div>
         );
@@ -45,7 +47,7 @@ const ContractHistory = ({ currency, history = [] }: TContractHistory) => {
                                     )}
                                 </React.Fragment>
                             ) : (
-                                localize('Cancelled')
+                                <Localize i18n_default_text='Cancelled' />
                             )
                         }
                     />

--- a/packages/trader/src/App/Components/Elements/EmptyPortfolioMessage/empty-portfolio-message.tsx
+++ b/packages/trader/src/App/Components/Elements/EmptyPortfolioMessage/empty-portfolio-message.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Text } from '@deriv/components';
 import { LegacyPositionIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 type TEmptyPortfolioMessage = {
     error?: string;
@@ -23,7 +23,7 @@ const EmptyPortfolioMessage = ({ error }: TEmptyPortfolioMessage) => (
                         fill='var(--color-text-disabled)'
                     />
                     <Text align='center' className='portfolio-empty__text' color='disabled' size='xs'>
-                        {localize('You have no open positions.')}
+                        <Localize i18n_default_text='You have no open positions.' />
                     </Text>
                 </React.Fragment>
             )}

--- a/packages/trader/src/App/Components/Elements/Errors/error-component.tsx
+++ b/packages/trader/src/App/Components/Elements/Errors/error-component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Dialog, PageErrorContainer } from '@deriv/components';
 import { routes } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 type TErrorComponent = {
     header: React.ReactNode;
@@ -21,6 +21,7 @@ const ErrorComponent: React.FC<Partial<TErrorComponent>> = ({
     redirectOnClick,
     should_show_refresh = true,
 }) => {
+    const { localize } = useTranslations();
     const refresh_message: string = should_show_refresh ? localize('Please refresh this page to continue.') : '';
 
     if (is_dialog) {

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/account-verification-required-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/account-verification-required-modal.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { Button, Modal } from '@deriv/components';
-import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TAccountVerificationRequiredModalProps = {
     is_visible: boolean;
@@ -13,7 +11,7 @@ type TAccountVerificationRequiredModalProps = {
 
 const AccountVerificationRequiredModal = observer(
     ({ is_visible, onConfirm }: TAccountVerificationRequiredModalProps) => {
-        const history = useHistory();
+        const { localize } = useTranslations();
         const {
             ui: { is_mobile },
         } = useStore();

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/authorization-required-modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, Modal } from '@deriv/components';
 import { redirectToLogin, redirectToSignUp } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 type TAuthorizationRequiredModal = {
     is_visible: boolean;
@@ -10,20 +10,23 @@ type TAuthorizationRequiredModal = {
     is_logged_in: boolean;
 };
 
-const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => (
-    <Modal
-        id='dt_authorization_required_modal'
-        is_open={is_visible}
-        small
-        toggleModal={toggleModal}
-        title={localize('Start trading with us')}
-    >
-        <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
-        <Modal.Footer>
-            <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
-            <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
-        </Modal.Footer>
-    </Modal>
-);
+const AuthorizationRequiredModal = ({ is_visible, toggleModal }: TAuthorizationRequiredModal) => {
+    const { localize } = useTranslations();
+    return (
+        <Modal
+            id='dt_authorization_required_modal'
+            is_open={is_visible}
+            small
+            toggleModal={toggleModal}
+            title={localize('Start trading with us')}
+        >
+            <Modal.Body>{localize('Log in or create a free account to place a trade.')}</Modal.Body>
+            <Modal.Footer>
+                <Button has_effect text={localize('Log in')} onClick={() => redirectToLogin()} secondary />
+                <Button has_effect text={localize('Create free account')} onClick={() => redirectToSignUp()} primary />
+            </Modal.Footer>
+        </Modal>
+    );
+};
 
 export default AuthorizationRequiredModal;

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/company-wide-limit-exceeded-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/company-wide-limit-exceeded-modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button, Modal, StaticUrl } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TCompanyWideLimitExceededModal = {
     is_visible: boolean;
@@ -10,6 +10,7 @@ type TCompanyWideLimitExceededModal = {
 };
 
 const CompanyWideLimitExceededModal = observer(({ is_visible, onConfirm }: TCompanyWideLimitExceededModal) => {
+    const { localize } = useTranslations();
     const {
         ui: { is_mobile },
     } = useStore();

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/insufficient-balance-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/insufficient-balance-modal.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { Button, Modal } from '@deriv/components';
-import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 type TInsufficientBalanceModal = RouteComponentProps & {
     is_virtual?: boolean;
@@ -14,12 +13,11 @@ type TInsufficientBalanceModal = RouteComponentProps & {
 };
 
 const InsufficientBalanceModal = observer(
-    ({ history, is_virtual, is_visible, message, toggleModal }: TInsufficientBalanceModal) => {
+    ({ is_virtual, is_visible, message, toggleModal }: TInsufficientBalanceModal) => {
         const {
             ui: { is_mobile },
-            client,
         } = useStore();
-        const { has_wallet } = client;
+        const { localize } = useTranslations();
         return (
             <Modal
                 id='dt_insufficient_balance_modal'

--- a/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/services-error-modal.tsx
+++ b/packages/trader/src/App/Components/Elements/Modals/ServicesErrorModal/services-error-modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, Modal } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import AccountVerificationRequiredModal from './account-verification-required-modal';
 import AuthorizationRequiredModal from './authorization-required-modal';
@@ -31,6 +31,7 @@ const ServicesErrorModal = ({
     services_error,
 }: TPropServicesErrorModel) => {
     const { code, message, type } = services_error;
+    const { localize } = useTranslations();
 
     if (!code || !message) return <React.Fragment />;
     switch (code) {

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-drawer.tsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-drawer.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 
 import { DataList, Money, PositionsDrawerCard, Text } from '@deriv/components';
 import { LegacyMinimize2pxIcon } from '@deriv/quill-icons';
-import { useNewRowTransition, getEndTime } from '@deriv/shared';
+import { getEndTime, useNewRowTransition } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -198,7 +198,7 @@ const PositionsDrawer = observer(({ ...props }) => {
             >
                 <div className='positions-drawer__header'>
                     <Text color='primary' weight='bold' size='xs'>
-                        {localize('Open positions')}
+                        <Localize i18n_default_text='Open positions' />
                     </Text>
                     <div
                         data-testid='dt_positions_drawer_close_icon'
@@ -221,11 +221,11 @@ const PositionsDrawer = observer(({ ...props }) => {
                         <div className='positions-drawer__summary'>
                             <Text size='xxs' color='less-prominent' className='positions-drawer__count'>
                                 {all_positions.length}{' '}
-                                {`${all_positions.length > 1 ? localize('open positions') : localize('open position')}`}
+                                {`${all_positions.length > 1 ? <Localize i18n_default_text='open positions' /> : <Localize i18n_default_text='open position' />}`}
                             </Text>
                             <div className='positions-drawer__total'>
                                 <Text size='xs' weight='bold'>
-                                    {localize('Total P/L:')}
+                                    <Localize i18n_default_text='Total P/L:' />
                                 </Text>
                                 <Text
                                     size='xs'

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.tsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.tsx
@@ -3,10 +3,10 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import { Div100vhContainer, Modal, Text } from '@deriv/components';
-import { LegacyPositionIcon, LegacyMinimize2pxIcon } from '@deriv/quill-icons';
+import { LegacyMinimize2pxIcon, LegacyPositionIcon } from '@deriv/quill-icons';
 import { isDisabledLandscapeBlockerRoute, isMobileOs, isTabletOs, routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import PositionsModalCard from 'App/Components/Elements/PositionsDrawer/positions-modal-card';
@@ -125,7 +125,7 @@ const TogglePositionsMobile = observer(
                                         className='positions-modal__title-icon'
                                         fill='var(--color-text-primary)'
                                     />
-                                    {localize('Recent positions')}
+                                    <Localize i18n_default_text='Recent positions' />
                                 </Text>
                                 <div className='positions-modal__close-btn' onClick={closeModal}>
                                     <LegacyMinimize2pxIcon
@@ -149,7 +149,7 @@ const TogglePositionsMobile = observer(
                                     to={routes.positions}
                                 >
                                     <Text size='xs' weight='bold'>
-                                        {localize('Go to Reports')}
+                                        <Localize i18n_default_text='Go to Reports' />
                                     </Text>
                                 </NavLink>
                             </div>

--- a/packages/trader/src/App/Components/Elements/market-is-closed-overlay.tsx
+++ b/packages/trader/src/App/Components/Elements/market-is-closed-overlay.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import { Button, Text, UILoader } from '@deriv/components';
 import { useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from '../../../Stores/useTraderStores';
 
@@ -27,6 +27,7 @@ const MarketIsClosedOverlay = ({
     symbol,
 }: TMarketIsClosedOverlay) => {
     const [is_timer_loading, setIsTimerLoading] = React.useState(true);
+    const { localize } = useTranslations();
 
     let message: JSX.Element | null = (
         <Localize i18n_default_text='In the meantime, try our synthetic indices. They simulate real-market volatility and are open 24/7.' />

--- a/packages/trader/src/App/Components/Form/RangeSlider/range-slider.tsx
+++ b/packages/trader/src/App/Components/Form/RangeSlider/range-slider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { Text } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { useTranslations, Localize } from '@deriv-com/translations';
 
 import TickSteps from './tick-steps';
 
@@ -103,8 +103,12 @@ const RangeSlider = ({ className, name, value, min_value, max_value, onChange }:
             <div className='range-slider__caption'>
                 {!!display_value && (
                     <Text align='center' weight='bold' size='xs' color='primary' id='dt_range_slider_label'>
-                        {display_value === 1 && localize('{{display_value}} Tick', { display_value })}
-                        {display_value > 1 && localize('{{display_value}} Ticks', { display_value })}
+                        {display_value === 1 && (
+                            <Localize i18n_default_text='{{display_value}} Tick' values={{ display_value }} />
+                        )}
+                        {display_value > 1 && (
+                            <Localize i18n_default_text='{{display_value}} Ticks' values={{ display_value }} />
+                        )}
                     </Text>
                 )}
             </div>

--- a/packages/trader/src/App/Components/Form/TimePicker/dialog.tsx
+++ b/packages/trader/src/App/Components/Form/TimePicker/dialog.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { toMoment } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 type TDialogProps = {
     className: string;
@@ -59,7 +59,9 @@ const Dialog = ({ preClass, selected_time, end_times, start_times, onChange, cla
             <div className={`${preClass}__selector`}>
                 <div className={`${preClass}__selector--hours`}>
                     <div className={classNames(`${preClass}__selector-list-title`, 'center-text')}>
-                        <strong>{localize('Hour')}</strong>
+                        <strong>
+                            <Localize i18n_default_text='Hour' />
+                        </strong>
                     </div>
                     <div>
                         {hours.map(h => {
@@ -104,7 +106,9 @@ const Dialog = ({ preClass, selected_time, end_times, start_times, onChange, cla
                 </div>
                 <div className={`${preClass}__selector--minutes`}>
                     <div className={classNames(`${preClass}__selector-list-title`, 'center-text')}>
-                        <strong>{localize('Minute')}</strong>
+                        <strong>
+                            <Localize i18n_default_text='Minute' />
+                        </strong>
                     </div>
                     <div>
                         {minutes.map(mm => {

--- a/packages/trader/src/App/Containers/trade-settings-extensions.tsx
+++ b/packages/trader/src/App/Containers/trade-settings-extensions.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import Loadable from 'react-loadable';
 
 import { UILoader } from '@deriv/components';
+import { LegacyChartsIcon } from '@deriv/quill-icons';
 import { observer, useStore } from '@deriv/stores';
 import type { TCoreStores } from '@deriv/stores/types';
-import { localize } from '@deriv-com/translations';
-import { LegacyChartsIcon } from '@deriv/quill-icons';
+import { useTranslations } from '@deriv-com/translations';
+
 import TraderProviders from '../../trader-providers';
 
 type TTradeSettingsExtensionsProps = {
@@ -27,6 +28,7 @@ const renderItemValue = <T extends object>(props: T, store: TCoreStores) => (
 );
 
 const TradeSettingsExtensions = observer(({ store }: TTradeSettingsExtensionsProps) => {
+    const { localize } = useTranslations();
     const { ui } = useStore();
     const { populateSettingsExtensions } = ui;
     const populateSettings = () => {

--- a/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
+++ b/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
@@ -9,7 +9,7 @@ import {
     isValidToCancel,
 } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 import { ActionSheet, Text, TextField, TextFieldWithSteppers, ToggleSwitch } from '@deriv-com/quill-ui';
 
 import useContractDetails from 'AppV2/Hooks/useContractDetails';
@@ -40,6 +40,7 @@ const RiskManagementItem = observer(
         const is_valid_to_cancel = isValidToCancel(contract_info);
         const is_accumulator = isAccumulatorContract(contract_type);
         const total_profit = getProfit(contract_info);
+        const { localize } = useTranslations();
 
         React.useEffect(() => {
             if (value) {

--- a/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/services-error-snackbar.tsx
+++ b/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/services-error-snackbar.tsx
@@ -3,8 +3,8 @@ import { useLocation } from 'react-router-dom';
 
 import { getStaticUrl, isEmptyObject, isValidToCancel, routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
 import { SnackbarController, useSnackbar } from '@deriv-com/quill-ui';
+import { useTranslations } from '@deriv-com/translations';
 
 import useContractDetails from 'AppV2/Hooks/useContractDetails';
 import { checkIsServiceModalError, SERVICE_ERROR } from 'AppV2/Utils/layout-utils';
@@ -12,6 +12,7 @@ import { getDisplayedContractTypes } from 'AppV2/Utils/trade-types-utils';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 const ServicesErrorSnackbar = observer(() => {
+    const { localize } = useTranslations();
     const {
         common: { services_error, resetServicesError },
         client: { is_logged_in },

--- a/packages/trader/src/AppV2/Components/SymbolNotFound/symbol-not-found.tsx
+++ b/packages/trader/src/AppV2/Components/SymbolNotFound/symbol-not-found.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { Localize, localize } from '@deriv-com/translations';
 import { Text } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 const SymbolNotFound = ({ searchTerm }: { searchTerm?: string }) => {
+    const { localize } = useTranslations();
     return (
         <div className='symbol-not-found__container'>
             <div className='symbol-not-found__content'>

--- a/packages/trader/src/AppV2/Components/SymbolsSearchField/symbols-search-field.tsx
+++ b/packages/trader/src/AppV2/Components/SymbolsSearchField/symbols-search-field.tsx
@@ -3,8 +3,8 @@ import clsx from 'clsx';
 
 import { getContractTypesConfig } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
 import { Button, SearchField } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -22,6 +22,7 @@ const SymbolsSearchField = observer(
         const { contract_type } = useTraderStore();
         const contract_name = getContractTypesConfig()[contract_type]?.title;
         const inputRef = useRef<HTMLInputElement | null>(null);
+        const { localize } = useTranslations();
 
         useEffect(() => {
             const inputElement = inputRef.current;

--- a/packages/trader/src/AppV2/Components/TakeProfitHistory/take-profit-history.tsx
+++ b/packages/trader/src/AppV2/Components/TakeProfitHistory/take-profit-history.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import clsx from 'classnames';
 
 import { formatDate, formatMoney, formatTime, TContractStore } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { CaptionText, Pagination, Text } from '@deriv-com/quill-ui';
+import { Localize } from '@deriv-com/translations';
 
 import Carousel from 'AppV2/Components/Carousel';
 
@@ -67,9 +67,11 @@ const TakeProfitHistory = ({ history = [], currency, is_multiplier }: TContractH
                                 {item.display_name}
                             </Text>
                             <Text size='sm'>
-                                {Math.abs(Number(item.order_amount)) === 0
-                                    ? localize('Cancelled')
-                                    : `${formatMoney(String(currency), String(item.order_amount), true)} ${currency}`}
+                                {Math.abs(Number(item.order_amount)) === 0 ? (
+                                    <Localize i18n_default_text='Cancelled' />
+                                ) : (
+                                    `${formatMoney(String(currency), String(item.order_amount), true)} ${currency}`
+                                )}
                             </Text>
                         </div>
                     </div>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
 
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, Chip, Text, TextField, TextFieldAddon } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -31,6 +31,7 @@ const BarrierInput = observer(
         const [option, setOption] = React.useState(0);
         const [should_show_error, setShouldShowError] = React.useState(false);
         const [previous_value, setPreviousValue] = React.useState(barrier_1);
+        const { localize } = useTranslations();
 
         // Constants for localStorage keys
         const SPOT_BARRIER_KEY = 'deriv_spot_barrier_value';

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -4,8 +4,8 @@ import { observer } from 'mobx-react-lite';
 
 import { getTomorrowDate, getUnitMap, toMoment } from '@deriv/shared';
 import { useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, TextField, useSnackbar } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { getDatePickerStartDate, getSmallestDuration, isValidPersistedDuration } from 'AppV2/Utils/trade-params-utils';
 import { getDisplayedContractTypes } from 'AppV2/Utils/trade-types-utils';
@@ -57,6 +57,7 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
     const { common, client } = useStore();
     const { is_logged_in } = client;
     const { server_time } = common;
+    const { localize } = useTranslations();
 
     useEffect(() => {
         if (expiry_epoch && duration_unit !== 'd' && !saved_expiry_date_v2) {

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/hourpicker.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/hourpicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
-import { localize } from '@deriv-com/translations';
 import { WheelPickerContainer } from '@deriv-com/quill-ui';
+import { useTranslations } from '@deriv-com/translations';
 
 type TimeOption = {
     label: string;
@@ -21,6 +21,7 @@ const HourPicker = ({
 }) => {
     const [hours, setHours] = useState<TimeOption[]>([]);
     const [minutes, setMinutes] = useState<TimeOption[]>([]);
+    const { localize } = useTranslations();
 
     useEffect(() => {
         const min_seconds = Math.max(duration_min_max.intraday.min, 3600);

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate-picker.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate-picker.tsx
@@ -3,8 +3,8 @@ import debounce from 'lodash.debounce';
 
 import { Skeleton } from '@deriv/components';
 import { getGrowthRatePercentage } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, Text, WheelPicker } from '@deriv-com/quill-ui';
+import { Localize } from '@deriv-com/translations';
 
 import type { TV2ParamsInitialValues } from 'Stores/Modules/Trading/trade-store';
 
@@ -41,7 +41,7 @@ const GrowthRatePicker = ({
         },
         {
             label: <Localize i18n_default_text='Max duration' />,
-            value: `${maximum_ticks || 0} ${maximum_ticks === 1 ? localize('tick') : localize('ticks')}`,
+            value: `${maximum_ticks || 0} ${maximum_ticks === 1 ? <Localize i18n_default_text='tick' /> : <Localize i18n_default_text='ticks' />}`,
         },
     ];
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -3,8 +3,8 @@ import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
 
 import { getCurrencyDisplayCode } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, TextField } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
@@ -19,6 +19,7 @@ import RiskManagementContent from './risk-management-content';
 import RiskManagementPicker from './risk-management-picker';
 
 const RiskManagement = observer(({ is_minimized }: TTradeParametersProps) => {
+    const { localize } = useTranslations();
     const [is_open, setIsOpen] = React.useState(false);
     const {
         cancellation_range_list,

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
@@ -3,8 +3,8 @@ import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
 
 import { getCurrencyDisplayCode, getDecimalPlaces } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, CaptionText, Text, TextFieldWithSteppers, ToggleSwitch } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useDtraderQuery } from 'AppV2/Hooks/useDtraderQuery';
 import useIsVirtualKeyboardOpen from 'AppV2/Hooks/useIsVirtualKeyboardOpen';
@@ -44,6 +44,7 @@ const TakeProfitAndStopLossInput = ({
     parent_is_api_response_received_ref,
     type = 'take_profit',
 }: TTakeProfitAndStopLossInputProps) => {
+    const { localize } = useTranslations();
     const trade_store = useTraderStore();
     const {
         contract_type,

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake-input.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { observer } from 'mobx-react-lite';
 
 import { formatMoney, getCurrencyDisplayCode, getDecimalPlaces } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
 import { ActionSheet, TextFieldWithSteppers } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useFetchProposalData } from 'AppV2/Hooks/useFetchProposalData';
 import useIsVirtualKeyboardOpen from 'AppV2/Hooks/useIsVirtualKeyboardOpen';
@@ -148,6 +148,7 @@ const calculateMaxLength = (amount: number | string, decimals: number): number =
 };
 
 const StakeInput = observer(({ onClose, is_open }: TStakeInput) => {
+    const { localize } = useTranslations();
     const trade_store = useTraderStore();
     const {
         contract_type,

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 
 import { LabelPairedPresentationScreenSmRegularIcon } from '@deriv/quill-icons';
-import { Localize, localize } from '@deriv-com/translations';
 import { safeParse } from '@deriv/utils';
 import { ActionSheet, Button, Chip, Text } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
@@ -44,6 +44,7 @@ export type TResultItem = {
 };
 
 const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mode_on }: TTradeTypesProps) => {
+    const { localize } = useTranslations();
     const [is_open, setIsOpen] = React.useState<boolean>(false);
     const [is_editing, setIsEditing] = React.useState<boolean>(false);
     const trade_types_ref = React.useRef<HTMLDivElement>(null);

--- a/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats-manual-modal.tsx
+++ b/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats-manual-modal.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Loading, Modal, Text } from '@deriv/components';
 import { LegacyInfo1pxIcon } from '@deriv/quill-icons';
 import { getUrlBase, isMobile } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import 'Sass/app/modules/contract/accumulators-stats.scss';
 
@@ -70,7 +70,7 @@ const AccumulatorsStatsManualModal = ({
                             {/* a browser will select a source with extension it recognizes */}
                             <source src={mp4_src} type='video/mp4' />
                             <source src={webm_src} type='video/webm' />
-                            {localize('Unfortunately, your browser does not support the video.')}
+                            <Localize i18n_default_text='Unfortunately, your browser does not support the video.' />
                         </video>
                     </div>
                     <Text
@@ -79,9 +79,7 @@ const AccumulatorsStatsManualModal = ({
                         color='primary'
                         className='accumulators-stats-modal-body__text'
                     >
-                        {localize(
-                            'Stats show the history of consecutive tick counts, i.e. the number of ticks the price remained within range continuously.'
-                        )}
+                        <Localize i18n_default_text='Stats show the history of consecutive tick counts, i.e. the number of ticks the price remained within range continuously.' />
                     </Text>
                 </Modal.Body>
             </Modal>

--- a/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats.tsx
+++ b/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { MobileDialog, Text } from '@deriv/components';
-import { LegacyArrowUp1pxIcon, LegacyArrowDown1pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowDown1pxIcon, LegacyArrowUp1pxIcon } from '@deriv/quill-icons';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -26,6 +26,7 @@ export const ROW_SIZES = {
 };
 
 const AccumulatorsStats = observer(({ is_expandable = true }: TAccumulatorStats) => {
+    const { localize } = useTranslations();
     const { ui } = useStore();
     const { ticks_history_stats = {} } = useTraderStore();
     const { is_dark_mode_on: is_dark_theme } = ui;

--- a/packages/trader/src/Modules/Contract/Containers/contract.tsx
+++ b/packages/trader/src/Modules/Contract/Containers/contract.tsx
@@ -5,7 +5,7 @@ import { CSSTransition } from 'react-transition-group';
 
 import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import ErrorComponent from 'App/Components/Elements/Errors';
 
@@ -17,6 +17,7 @@ type TContract = RouteComponentProps<TContractParams>;
 const dialog_errors = ['GetProposalFailure', 'ContractValidationError'];
 
 const Contract = observer(({ match, history }: TContract) => {
+    const { localize } = useTranslations();
     const { contract_replay } = useStore();
     const {
         removeErrorMessage,

--- a/packages/trader/src/Modules/Page404/Components/Page404.tsx
+++ b/packages/trader/src/Modules/Page404/Components/Page404.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 
 import { PageError } from '@deriv/components';
 import { getUrlBase, routes } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-const Page404 = () => (
-    <PageError
-        header={localize('We couldn’t find that page')}
-        messages={[
-            localize('You may have followed a broken link, or the page has moved to a new address.'),
-            localize('Error code: {{error_code}} page not found', { error_code: 404 }),
-        ]}
-        redirect_urls={[routes.index]}
-        redirect_labels={[localize('Return to trade')]}
-        classNameImage='page-404__image'
-        image_url={getUrlBase('/public/images/common/404.png')}
-    />
-);
+const Page404 = () => {
+    const { localize } = useTranslations();
+    return (
+        <PageError
+            header={localize('We couldn’t find that page')}
+            messages={[
+                localize('You may have followed a broken link, or the page has moved to a new address.'),
+                localize('Error code: {{error_code}} page not found', { error_code: 404 }),
+            ]}
+            redirect_urls={[routes.index]}
+            redirect_labels={[localize('Return to trade')]}
+            classNameImage='page-404__image'
+            image_url={getUrlBase('/public/images/common/404.png')}
+        />
+    );
+};
 
 export default Page404;

--- a/packages/trader/src/Modules/SmartChart/Components/Markers/accumulators-profit-loss-tooltip.tsx
+++ b/packages/trader/src/Modules/SmartChart/Components/Markers/accumulators-profit-loss-tooltip.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { Money, Text } from '@deriv/components';
 import { getDecimalPlaces } from '@deriv/shared';
 import { useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import { FastMarker } from 'Modules/SmartChart';
 
@@ -129,7 +129,7 @@ const AccumulatorsProfitLossTooltip = ({
             >
                 <div className={classNames(`${className}__content`, `arrow-${opposite_arrow_position}`)}>
                     <Text size={is_mobile ? 'xxxxs' : 'xxs'} className={`${className}__text`}>
-                        {localize('Total profit/loss:')}
+                        <Localize i18n_default_text='Total profit/loss:' />
                     </Text>
                     <Text size={is_mobile ? 'xxxs' : 'xs'} className={`${className}__text`} weight='bold'>
                         <Money amount={profit} currency={currency} has_sign show_currency />

--- a/packages/trader/src/Modules/Trading/Components/Elements/Multiplier/cancel-deal-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/Multiplier/cancel-deal-mobile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Checkbox, Dialog, Popover, RadioGroup, Text } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { onChangeCancellationDuration, onToggleCancellation } from 'Stores/Modules/Trading/Helpers/multiplier';
@@ -37,6 +37,7 @@ type TCancelDeal = {
 
 const DealCancellationWarningDialog = observer(
     ({ is_visible, onConfirm, onCancel }: TDealCancellationWarningDialog) => {
+        const { localize } = useTranslations();
         const { ui } = useStore();
         const { disableApp, enableApp, should_show_cancellation_warning, toggleCancellationWarning } = ui;
         return (
@@ -100,7 +101,7 @@ const CancelDeal = observer(
                                 }
                             }}
                             name='has_cancellation'
-                            label={localize('Deal cancellation')}
+                            label={<Localize i18n_default_text='Deal cancellation' />}
                             defaultChecked={has_cancellation}
                         />
                         <Popover
@@ -110,9 +111,9 @@ const CancelDeal = observer(
                             is_bubble_hover_enabled
                             classNameBubble='trade-container__deal-cancellation-popover'
                             zIndex='9999'
-                            message={localize(
-                                'When this is active, you can cancel your trade within the chosen time frame. Your stake will be returned without loss.'
-                            )}
+                            message={
+                                <Localize i18n_default_text='When this is active, you can cancel your trade within the chosen time frame. Your stake will be returned without loss.' />
+                            }
                         />
                     </div>
                     {has_cancellation && (

--- a/packages/trader/src/Modules/Trading/Components/Elements/Multiplier/risk-management-info.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/Multiplier/risk-management-info.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Money } from '@deriv/components';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import RiskManagementDialog from 'Modules/Trading/Containers/Multiplier/risk-management-dialog';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -38,13 +38,19 @@ const RiskManagementInfo = observer(() => {
             >
                 {!has_risk_management && (
                     <div className='mobile-widget__item'>
-                        <div className='mobile-widget__item-label'>{localize('Risk management')}</div>
-                        <div className='mobile-widget__item-value'>{localize('Not set')}</div>
+                        <div className='mobile-widget__item-label'>
+                            <Localize i18n_default_text='Risk management' />
+                        </div>
+                        <div className='mobile-widget__item-value'>
+                            <Localize i18n_default_text='Not set' />
+                        </div>
                     </div>
                 )}
                 {has_take_profit && (
                     <div className='mobile-widget__item'>
-                        <div className='mobile-widget__item-label'>{localize('Take profit')}</div>
+                        <div className='mobile-widget__item-label'>
+                            <Localize i18n_default_text='Take profit' />
+                        </div>
                         <div className='mobile-widget__item-value'>
                             <Money amount={take_profit} currency={currency} show_currency />
                         </div>
@@ -52,7 +58,9 @@ const RiskManagementInfo = observer(() => {
                 )}
                 {has_stop_loss && (
                     <div className='mobile-widget__item'>
-                        <div className='mobile-widget__item-label'>{localize('Stop loss')}</div>
+                        <div className='mobile-widget__item-label'>
+                            <Localize i18n_default_text='Stop loss' />
+                        </div>
                         <div className='mobile-widget__item-value'>
                             <Money amount={stop_loss} currency={currency} show_currency />
                         </div>
@@ -60,7 +68,9 @@ const RiskManagementInfo = observer(() => {
                 )}
                 {has_cancellation && (
                     <div className='mobile-widget__item'>
-                        <div className='mobile-widget__item-label'>{localize('Deal Cancellation')}</div>
+                        <div className='mobile-widget__item-label'>
+                            <Localize i18n_default_text='Deal Cancellation' />
+                        </div>
                         <div className='mobile-widget__item-value'>{cancellation_label}</div>
                     </div>
                 )}

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeInfo/contract-type-info.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeInfo/contract-type-info.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { Button, ButtonToggle, Dropdown, ThemedScrollbars } from '@deriv/components';
 import { clickAndKeyEventHandler, TRADE_TYPES } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
 import { Analytics } from '@deriv-com/analytics';
+import { useTranslations } from '@deriv-com/translations';
 
 import TradeCategories from 'Assets/Trading/Categories/trade-categories';
 import TradeCategoriesGIF from 'Assets/Trading/Categories/trade-categories-gif';
@@ -35,6 +35,7 @@ const TABS = {
 type TSelectedTab = 'description' | 'glossary';
 
 const Info = observer(({ handleSelect, item, selected_value, list, info_banner }: TInfo) => {
+    const { localize } = useTranslations();
     const { cached_multiplier_cancellation_list } = useTraderStore();
     const {
         ui: { is_mobile },

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/contract-type-menu.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/contract-type-menu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 
 import { Loading, ThemedScrollbars, VerticalTab } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { getContractCategoryKey } from '../../../../Helpers/contract-type';
 import ContractType from '../contract-type';
@@ -49,6 +49,7 @@ const Dialog = ({
     hide_back_button,
     title,
 }: React.PropsWithChildren<TDialog>) => {
+    const { localize } = useTranslations();
     const input_ref = React.useRef<(HTMLInputElement & HTMLTextAreaElement) | null>(null);
     const [input_value, setInputValue] = React.useState('');
     const contract_category = getContractCategoryKey(categories, item);

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/no-results-message.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/no-results-message.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 
 import { Text } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
-const NoResultsMessage = ({ text }: { text: string }) => (
-    <div className='no-results-found'>
-        <h2 className='no-results-found__title'>
-            {localize('No results for "{{text}}"', { text, interpolation: { escapeValue: false } })}
-        </h2>
-        <Text as='p' size='xxs' align='center' color='less-prominent' className='no-results-found__subtitle'>
-            {localize('Try checking your spelling or use a different term')}
-        </Text>
-    </div>
-);
+const NoResultsMessage = ({ text }: { text: string }) => {
+    const { localize } = useTranslations();
+    return (
+        <div className='no-results-found'>
+            <h2 className='no-results-found__title'>
+                {localize('No results for "{{text}}"', { text, interpolation: { escapeValue: false } })}
+            </h2>
+            <Text as='p' size='xxs' align='center' color='less-prominent' className='no-results-found__subtitle'>
+                {localize('Try checking your spelling or use a different term')}
+            </Text>
+        </div>
+    );
+};
 
 export default NoResultsMessage;

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/search-input.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/ContractTypeMenu/search-input.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { Input } from '@deriv/components';
-import { LegacySearch1pxIcon, LegacyCloseCircle1pxBlackIcon } from '@deriv/quill-icons';
-import { localize } from '@deriv-com/translations';
+import { LegacyCloseCircle1pxBlackIcon, LegacySearch1pxIcon } from '@deriv/quill-icons';
+import { useTranslations } from '@deriv-com/translations';
 
 type TSearchInput = {
     onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | null>;
@@ -12,21 +12,24 @@ type TSearchInput = {
 };
 
 const SearchInput = React.forwardRef<HTMLInputElement & HTMLTextAreaElement, TSearchInput>(
-    ({ onChange, onClickClearInput, onBlur, value }, ref) => (
-        <Input
-            ref={ref}
-            data-lpignore='true'
-            leading_icon={<LegacySearch1pxIcon iconSize='xs' />}
-            trailing_icon={
-                value ? <LegacyCloseCircle1pxBlackIcon onClick={onClickClearInput} iconSize='xs' /> : undefined
-            }
-            placeholder={localize('Search')}
-            type='text'
-            onChange={onChange}
-            onBlur={onBlur}
-            value={value}
-        />
-    )
+    ({ onChange, onClickClearInput, onBlur, value }, ref) => {
+        const { localize } = useTranslations();
+        return (
+            <Input
+                ref={ref}
+                data-lpignore='true'
+                leading_icon={<LegacySearch1pxIcon iconSize='xs' />}
+                trailing_icon={
+                    value ? <LegacyCloseCircle1pxBlackIcon onClick={onClickClearInput} iconSize='xs' /> : undefined
+                }
+                placeholder={localize('Search')}
+                type='text'
+                onChange={onChange}
+                onBlur={onBlur}
+                value={value}
+            />
+        );
+    }
 );
 
 SearchInput.displayName = 'SearchInput';

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { MobileDialog } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import { Header } from './ContractTypeInfo';
@@ -57,7 +57,7 @@ const ContractTypeDialog = ({
             should_render_arrow={!hide_back_button}
         />
     ) : (
-        localize('Trade types')
+        <Localize i18n_default_text='Trade types' />
     );
 
     if (isMobile) {

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import { Text } from '@deriv/components';
 import { TRADE_TYPES } from '@deriv/shared';
-import { localize } from '@deriv-com/translations';
 
 import Item from './contract-type-item';
 import { TContractCategory, TContractType, TFilteredContractType } from './types';

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.tsx
@@ -4,8 +4,8 @@ import { InlineMessage, Text } from '@deriv/components';
 import { LegacyChevronRight1pxIcon } from '@deriv/quill-icons';
 import { CONTRACT_STORAGE_VALUES, getSymbolDisplayName, TRADE_TYPES } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
 import { Analytics } from '@deriv-com/analytics';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -39,6 +39,7 @@ const ContractTypeWidget = observer(
             active_symbols: { active_symbols },
             ui: { is_mobile },
         } = useStore();
+        const { localize } = useTranslations();
         const { symbol, contract_type } = useTraderStore();
         const wrapper_ref = React.useRef<HTMLDivElement | null>(null);
         const [is_dialog_open, setDialogVisibility] = React.useState<boolean | null>();

--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { DatePicker, Tooltip } from '@deriv/components';
 import { getTomorrowDate, hasIntradayDurationUnit, isTimeValid, setTime, toMoment, useIsMounted } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { ContractType } from 'Stores/Modules/Trading/Helpers/contract-type';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -23,6 +23,7 @@ type TTradingDatePickerProps = {
 };
 
 const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TTradingDatePickerProps) => {
+    const { localize } = useTranslations();
     const { common } = useStore();
     const { server_time } = common;
     const {

--- a/packages/trader/src/Modules/Trading/Components/Form/Purchase/cancel-deal-info.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/Purchase/cancel-deal-info.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Money } from '@deriv/components';
 import { getDecimalPlaces, isDesktop, isMobile } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 import { TProposalTypeInfo } from 'Types';
@@ -44,7 +44,7 @@ const CancelDealInfo = observer(
                 {cancellation && (
                     <React.Fragment>
                         <div className='trade-container__price-info-basis' ref={ref}>
-                            {localize('Deal cancel. fee')}
+                            <Localize i18n_default_text='Deal cancel. fee' />
                         </div>
                         <div className='trade-container__price-info-value'>
                             {!error && (

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulator.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulator.tsx
@@ -3,13 +3,14 @@ import classNames from 'classnames';
 
 import { getGrowthRatePercentage, isEmptyObject } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import NumberSelector from 'App/Components/Form/number-selector';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 const Accumulator = observer(() => {
+    const { localize } = useTranslations();
     const {
         accumulator_range_list,
         growth_rate,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-amount-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-amount-mobile.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { MobileWrapper } from '@deriv/components';
 import { AMOUNT_MAX_LENGTH, getDecimalPlaces } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -15,6 +15,7 @@ const AccumulatorsAmountMobile = observer(() => {
     const { current_focus, setCurrentFocus } = ui;
     const { is_single_currency } = client;
     const { amount, currency, onChange, has_open_accu_contract } = useTraderStore();
+    const { localize } = useTranslations();
     return (
         <>
             <MobileWrapper>

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-info-display.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-info-display.tsx
@@ -4,12 +4,13 @@ import classNames from 'classnames';
 import { Money, Popover, Text } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 const AccumulatorsInfoDisplay = observer(() => {
+    const { localize } = useTranslations();
     const { currency, maximum_payout, maximum_ticks } = useTraderStore();
 
     const content = [

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { RelativeDatepicker, Tabs } from '@deriv/components';
 import { getDurationMinMaxValues } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import type { TTradeParamsMobile } from 'Modules/Trading/Containers/trade-params-mobile';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -51,6 +51,7 @@ const DurationMobile = observer(
         t_duration,
         toggleModal,
     }: TDurationMobile) => {
+        const { localize } = useTranslations();
         const { duration_units_list, duration_min_max, basis: trade_basis } = useTraderStore();
         const duration_values = {
             t_duration,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-numbers-widget-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-numbers-widget-mobile.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { Numpad } from '@deriv/components';
 import { addComma, getDurationMinMaxValues, getUnitMap, isEmptyObject } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -57,6 +57,7 @@ const DurationNumbersWidgetMobile = observer(
             amount: trade_amount,
             onChangeMultiple,
         } = useTraderStore();
+        const { localize } = useTranslations();
         const { value: duration_unit } = duration_unit_option;
         const [min, max] = getDurationMinMaxValues(duration_min_max, contract_expiry, duration_unit);
         const [has_error, setHasError] = React.useState(false);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-ticks-widget-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-ticks-widget-mobile.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { TickPicker } from '@deriv/components';
 import { getDurationMinMaxValues, isEmptyObject } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -51,6 +51,7 @@ const DurationTicksWidgetMobile = observer(
             amount: trade_amount,
             onChangeMultiple,
         } = useTraderStore();
+        const { localize } = useTranslations();
 
         React.useEffect(() => {
             setDurationError(false);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-toggle.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-toggle.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { localize } from '@deriv-com/translations';
 import { LegacyChevronDown1pxIcon } from '@deriv/quill-icons';
+import { useTranslations } from '@deriv-com/translations';
 
 type TDurationToggle = {
     name: string;
@@ -11,6 +11,7 @@ type TDurationToggle = {
 };
 
 const DurationToggle = ({ name, onChange, value }: TDurationToggle) => {
+    const { localize } = useTranslations();
     const toggle = () => {
         onChange({ target: { value: !value, name } });
     };

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Dropdown } from '@deriv/components';
 import { isVanillaContract, toMoment } from '@deriv/shared';
 import { useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import RangeSlider from 'App/Components/Form/RangeSlider';
@@ -67,6 +67,8 @@ const Duration = ({
     simple_duration_unit,
     start_date,
 }: TDuration) => {
+    const { localize } = useTranslations();
+
     React.useEffect(() => {
         if (isVanillaContract(contract_type)) {
             onToggleDurationType({ target: { value: true, name: 'is_advanced_duration' } });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/cancel-deal.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/cancel-deal.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import { Checkbox, Dropdown, Popover, PopoverMessageCheckbox } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { onChangeCancellationDuration, onToggleCancellation } from 'Stores/Modules/Trading/Helpers/multiplier';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 const CancelDeal = observer(() => {
+    const { localize } = useTranslations();
     const { ui } = useStore();
     const {
         cancellation_range_list,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, Div100vhContainer, Modal, Text } from '@deriv/components';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Expiration from './expiration';
 
@@ -10,26 +10,36 @@ type TMultipliersExpirationModalProps = {
     toggleModal: () => void;
 };
 
-const MultipliersExpirationModal = ({ is_open, toggleModal }: TMultipliersExpirationModalProps) => (
-    <Modal
-        is_open={is_open}
-        toggleModal={toggleModal}
-        has_close_icon={false}
-        should_header_stick_body={false}
-        title={<Localize i18n_default_text='Expiration' />}
-    >
-        <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
-            <Text size='xs' color='secondary' as='div' className='dc-modal-body__expiration'>
-                <Localize
-                    i18n_default_text='Your contract will be closed automatically at the next available asset price on <0></0>.'
-                    components={[<Expiration key={0} is_text_only text_size='xs' />]}
-                />
-            </Text>
-            <Modal.Footer has_separator>
-                <Button className='dc-btn__wide' large primary has_effect text={localize('OK')} onClick={toggleModal} />
-            </Modal.Footer>
-        </Div100vhContainer>
-    </Modal>
-);
+const MultipliersExpirationModal = ({ is_open, toggleModal }: TMultipliersExpirationModalProps) => {
+    const { localize } = useTranslations();
+    return (
+        <Modal
+            is_open={is_open}
+            toggleModal={toggleModal}
+            has_close_icon={false}
+            should_header_stick_body={false}
+            title={<Localize i18n_default_text='Expiration' />}
+        >
+            <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
+                <Text size='xs' color='secondary' as='div' className='dc-modal-body__expiration'>
+                    <Localize
+                        i18n_default_text='Your contract will be closed automatically at the next available asset price on <0></0>.'
+                        components={[<Expiration key={0} is_text_only text_size='xs' />]}
+                    />
+                </Text>
+                <Modal.Footer has_separator>
+                    <Button
+                        className='dc-btn__wide'
+                        large
+                        primary
+                        has_effect
+                        text={localize('OK')}
+                        onClick={toggleModal}
+                    />
+                </Modal.Footer>
+            </Div100vhContainer>
+        </Modal>
+    );
+};
 
 export default MultipliersExpirationModal;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/stop-loss.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/stop-loss.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { InputWithCheckbox } from '@deriv/components';
 import { isDesktop } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -19,6 +19,7 @@ type TStopLossProps = {
 };
 
 const StopLoss = observer((props: TStopLossProps) => {
+    const { localize } = useTranslations();
     const { ui, client } = useStore();
     const trade = useTraderStore();
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/take-profit.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/take-profit.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { InputWithCheckbox } from '@deriv/components';
 import { isDesktop } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -22,6 +22,7 @@ type TTakeProfitProps = {
 const TakeProfit = observer((props: TTakeProfitProps) => {
     const { ui, client } = useStore();
     const trade = useTraderStore();
+    const { localize } = useTranslations();
 
     const { addToast, removeToast, current_focus, setCurrentFocus } = ui;
     const { is_single_currency } = client;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Money, Popover, Text } from '@deriv/components';
 import { clickAndKeyEventHandler, getGrowthRatePercentage } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import MultipliersExpiration from 'Modules/Trading/Components/Form/TradeParams/Multiplier/expiration';
 import MultipliersExpirationModal from 'Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal';
@@ -135,14 +135,14 @@ const RadioGroupOptionsWidget = ({
 export const MultiplierOptionsWidget = observer(() => {
     const { multiplier } = useTraderStore();
     const displayed_trade_param = `x${multiplier}`;
-    const modal_title = localize('Multiplier');
+    const modal_title = <Localize i18n_default_text='Multiplier' />;
     return <RadioGroupOptionsWidget displayed_trade_param={displayed_trade_param} modal_title={modal_title} />;
 });
 
 export const AccumulatorOptionsWidget = observer(() => {
     const { growth_rate, has_open_accu_contract, tick_size_barrier_percentage } = useTraderStore();
     const displayed_trade_param = `${getGrowthRatePercentage(growth_rate)}%`;
-    const modal_title = localize('Growth rate');
+    const modal_title = <Localize i18n_default_text='Growth rate' />;
     const tooltip_message = (
         <Localize
             i18n_default_text='Your stake will grow at {{growth_rate}}% per tick as long as the current spot price remains within ±{{tick_size_barrier_percentage}} from the previous spot price.'

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/allow-equals.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/allow-equals.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Checkbox, Popover } from '@deriv/components';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import {
     hasCallPutEqual,
@@ -29,6 +29,7 @@ const AllowEquals = ({
     value,
     has_equals_only,
 }: TAllowEquals) => {
+    const { localize } = useTranslations();
     const has_callputequal_duration = hasDurationForCallPutEqual(contract_types_list, duration_unit);
     const has_callputequal = hasCallPutEqual(contract_types_list);
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Money, Numpad, Tabs } from '@deriv/components';
 import { getDecimalPlaces, isEmptyObject } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -42,6 +42,7 @@ const Basis = observer(
         setSelectedAmount,
         setAmountError,
     }: TBasis) => {
+        const { localize } = useTranslations();
         const { ui, client } = useStore();
         const { addToast } = ui;
         const { currency } = client;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { ButtonToggle, Dropdown, InputField } from '@deriv/components';
 import { addComma, AMOUNT_MAX_LENGTH, getDecimalPlaces, TRADE_TYPES } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -34,34 +34,38 @@ export const Input = ({
     is_disabled,
     onChange,
     setCurrentFocus,
-}: TInput) => (
-    <InputField
-        className='trade-container__amount'
-        classNameInlinePrefix='trade-container__currency'
-        classNameInput='trade-container__input'
-        currency={currency}
-        current_focus={current_focus}
-        error_messages={error_messages}
-        fractional_digits={getDecimalPlaces(currency)}
-        id='dt_amount_input'
-        inline_prefix={is_single_currency ? currency : undefined}
-        is_autocomplete_disabled
-        is_float
-        is_hj_whitelisted
-        is_incrementable
-        is_negative_disabled
-        is_disabled={is_disabled}
-        max_length={AMOUNT_MAX_LENGTH}
-        name='amount'
-        onChange={onChange}
-        type='tel'
-        value={amount}
-        ariaLabel={localize('Amount')}
-        setCurrentFocus={setCurrentFocus}
-    />
-);
+}: TInput) => {
+    const { localize } = useTranslations();
+    return (
+        <InputField
+            className='trade-container__amount'
+            classNameInlinePrefix='trade-container__currency'
+            classNameInput='trade-container__input'
+            currency={currency}
+            current_focus={current_focus}
+            error_messages={error_messages}
+            fractional_digits={getDecimalPlaces(currency)}
+            id='dt_amount_input'
+            inline_prefix={is_single_currency ? currency : undefined}
+            is_autocomplete_disabled
+            is_float
+            is_hj_whitelisted
+            is_incrementable
+            is_negative_disabled
+            is_disabled={is_disabled}
+            max_length={AMOUNT_MAX_LENGTH}
+            name='amount'
+            onChange={onChange}
+            type='tel'
+            value={amount}
+            ariaLabel={localize('Amount')}
+            setCurrentFocus={setCurrentFocus}
+        />
+    );
+};
 
 const Amount = observer(({ is_minimized = false }: { is_minimized?: boolean }) => {
+    const { localize } = useTranslations();
     const { ui, client } = useStore();
     const { currencies_list, is_single_currency } = client;
     const { setCurrentFocus, current_focus } = ui;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/barrier.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/barrier.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { DesktopWrapper, InputField, MobileWrapper, Modal, Text } from '@deriv/components';
-import { LegacyArrowUp1pxIcon, LegacyArrowDown1pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowDown1pxIcon, LegacyArrowUp1pxIcon } from '@deriv/quill-icons';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -18,6 +18,7 @@ type TBarrier = {
 };
 
 const Barrier = observer(({ is_minimized, is_absolute_only }: TBarrier) => {
+    const { localize } = useTranslations();
     const { ui } = useStore();
     const { current_focus, setCurrentFocus } = ui;
     const {

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/last-digit.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/last-digit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { isDesktop } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import Fieldset from 'App/Components/Form/fieldset';
 import NumberSelector from 'App/Components/Form/number-selector';
@@ -13,6 +13,7 @@ type TLastDigit = {
 };
 
 const LastDigit = observer(({ is_minimized }: TLastDigit) => {
+    const { localize } = useTranslations();
     const { onChange, last_digit } = useTraderStore();
     if (is_minimized) {
         return <div className='fieldset-minimized'>{`${localize('Last Digit')}: ${last_digit}`}</div>;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/strike.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/strike.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Dropdown, InputField, Text } from '@deriv/components';
 import { clickAndKeyEventHandler, toMoment, TRADE_TYPES } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
 import Fieldset from 'App/Components/Form/fieldset';
@@ -14,6 +14,7 @@ import { useTraderStore } from 'Stores/useTraderStores';
 import BarriersList from './barriers-list';
 
 const Strike = observer(() => {
+    const { localize } = useTranslations();
     const { ui, common } = useStore();
     const {
         barrier_1,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/trade-type-tabs.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/trade-type-tabs.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { ButtonToggle } from '@deriv/components';
 import { isTurbosContract, isVanillaContract, TRADE_TYPES } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -13,6 +13,7 @@ type TTradeTypeTabs = {
 };
 
 const TradeTypeTabs = observer(({ className }: TTradeTypeTabs) => {
+    const { localize } = useTranslations();
     const { onChange, contract_type } = useTraderStore();
 
     const is_turbos = isTurbosContract(contract_type);

--- a/packages/trader/src/Modules/Trading/Containers/Multiplier/multiplier-amount-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/Multiplier/multiplier-amount-modal.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Div100vhContainer, Modal, usePreventIOSZoom } from '@deriv/components';
 import { CONTRACT_TYPES, useIsMounted, WS } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import AmountMobile from 'Modules/Trading/Components/Form/TradeParams/amount-mobile';
 import MultipliersInfo from 'Modules/Trading/Components/Form/TradeParams/Multiplier/info';
@@ -32,7 +32,7 @@ const MultiplierAmountModal = ({ is_open, toggleModal }: TMultiplierAmountModal)
                 toggleModal={toggleModal}
                 height='auto'
                 width='calc(100vw - 32px)'
-                title={localize('Stake')}
+                title={<Localize i18n_default_text='Stake' />}
             >
                 <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
                     <TradeParamsMobile toggleModal={toggleModal} />

--- a/packages/trader/src/Modules/Trading/Containers/Multiplier/risk-management-dialog.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/Multiplier/risk-management-dialog.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Button, Div100vhContainer, MobileDialog } from '@deriv/components';
 import { isDeepEqual, pick } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import CancelDeal from 'Modules/Trading/Components/Elements/Multiplier/cancel-deal-mobile';
 import StopLoss from 'Modules/Trading/Components/Form/TradeParams/Multiplier/stop-loss';
@@ -22,6 +22,7 @@ type TValidation_errors = {
 };
 
 const RiskManagementDialog = observer(({ is_open, onClose, toggleDialog }: TRiskManagementDialog) => {
+    const { localize } = useTranslations();
     const {
         is_turbos,
         take_profit,

--- a/packages/trader/src/Modules/Trading/Containers/allow-equals.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/allow-equals.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import { Checkbox, Text } from '@deriv/components';
 import { observer } from '@deriv/stores';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize } from '@deriv-com/translations';
 
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -26,7 +26,7 @@ const AllowEquals = ({ onChange, is_allow_equal, has_equals_only, className }: T
     return (
         <div className={classNames('allow-equals', 'mobile-widget', className)}>
             <Checkbox
-                label={localize('Equals')}
+                label={<Localize i18n_default_text='Equals' />}
                 value={is_allow_equal}
                 name='is_equal'
                 onChange={handleOnChange}

--- a/packages/trader/src/Modules/Trading/Containers/radio-group-options-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/radio-group-options-modal.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Div100vhContainer, Modal, usePreventIOSZoom } from '@deriv/components';
 import { getGrowthRatePercentage, isEmptyObject, TRADE_TYPES } from '@deriv/shared';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import RadioGroupWithInfoMobile from 'Modules/Trading/Components/Form/RadioGroupWithInfoMobile';
 import MultiplierOptions from 'Modules/Trading/Containers/Multiplier/multiplier-options';
@@ -16,6 +16,7 @@ type TRadioGroupOptionsModal = {
 };
 
 const RadioGroupOptionsModal = observer(({ is_open, modal_title, toggleModal }: TRadioGroupOptionsModal) => {
+    const { localize } = useTranslations();
     const { accumulator_range_list, growth_rate, onChange, tick_size_barrier_percentage, proposal_info } =
         useTraderStore();
 

--- a/packages/trader/src/Modules/Trading/Containers/strike-param-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/strike-param-modal.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import { Div100vhContainer, Modal, Popover, RadioGroup } from '@deriv/components';
 import { TRADE_TYPES } from '@deriv/shared';
-import { Localize, localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TStrikeParamModalProps = {
     contract_type: string;
@@ -24,6 +24,7 @@ const StrikeParamModal = ({
     name,
     strike_price_list,
 }: TStrikeParamModalProps) => {
+    const { localize } = useTranslations();
     return (
         <Modal
             className='trade-params dc-modal-header--title-bar'
@@ -33,7 +34,7 @@ const StrikeParamModal = ({
             toggleModal={toggleModal}
             height='auto'
             width='calc(100vw - 32px)'
-            title={localize('Strike')}
+            title={<Localize i18n_default_text='Strike' />}
         >
             <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
                 <div className='trade-params__vanilla-ic-info-wrapper'>

--- a/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import { Div100vhContainer, Modal, Money, Tabs, ThemedScrollbars, usePreventIOSZoom } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv-com/translations';
+import { useTranslations } from '@deriv-com/translations';
 
 import AmountMobile from 'Modules/Trading/Components/Form/TradeParams/amount-mobile';
 import Barrier from 'Modules/Trading/Components/Form/TradeParams/barrier';
@@ -228,6 +228,7 @@ const TradeParamsMobile = observer(
             is_vanilla,
             duration_unit: store_duration_unit,
         } = useTraderStore();
+        const { localize } = useTranslations();
 
         const resetToDefaultDuration = () => {
             const default_store_duration = getDefaultDuration(store_duration_unit);


### PR DESCRIPTION
This pull request refactors how translations are accessed throughout the codebase by replacing direct imports of the `localize` function with the `useTranslations` hook and, where appropriate, the `Localize` component. This change improves consistency, enables better support for context-based translations, and prepares the codebase for future enhancements in localization. The updates affect multiple components, including those in the video player, wallet card, footer, header, and various UI elements.

**Translation refactoring and consistency:**

* Replaced direct `localize` imports with the `useTranslations` hook in components 

* Updated button and label rendering to use the `Localize` component instead of calling `localize` directly, improving translation handling for static UI text (e.g., in `cookie-banner.jsx`). 

**Code organization and import cleanup:**

* Reordered and cleaned up import statements to group related imports and remove unused ones, improving readability and maintainability in several files. 

**Component structure updates:**

* Refactored some stateless functional components to use hooks for translation (e.g., `WalletCard`, `HelpCentre`, `ResponsibleTrading`, `CloseButton`), improving their structure and future extensibility.

These changes collectively enhance localization support, code quality, and maintainability across the affected components.