### PR TITLE
Farabi/grwt-6963/fix-error-on-reports-page

### DIFF
--- a/packages/reports/src/Components/empty-trade-history-message.tsx
+++ b/packages/reports/src/Components/empty-trade-history-message.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from '@deriv/components';
 
 type TEmptyTradeHistoryMessage = {
-    component_icon: React.ReactElement;
+    component_icon?: React.ReactElement;
     has_selected_date: boolean;
     localized_message: React.ReactNode;
     localized_period_message: React.ReactNode;
@@ -17,12 +17,14 @@ const EmptyTradeHistoryMessage = ({
     return (
         <React.Fragment>
             <div className='empty-trade-history'>
-                <div className='empty-trade-history__icon' data-testid='dt_empty_trade_history_icon'>
-                    {React.cloneElement(component_icon, {
-                        fill: 'var(--color-text-disabled)',
-                        iconSize: '2xl',
-                    })}
-                </div>
+                {component_icon && (
+                    <div className='empty-trade-history__icon' data-testid='dt_empty_trade_history_icon'>
+                        {React.cloneElement(component_icon, {
+                            fill: 'var(--color-text-disabled)',
+                            iconSize: '2xl',
+                        })}
+                    </div>
+                )}
                 <Text size='xs' align='center' color='disabled' className='empty-trade-history__text'>
                     {!has_selected_date ? localized_message : localized_period_message}
                 </Text>

--- a/packages/shared/src/utils/string/string_util.ts
+++ b/packages/shared/src/utils/string/string_util.ts
@@ -34,7 +34,7 @@ export const matchStringByChar = (s: string, p: string) => {
 export const numberToString = (n?: number | string | null) => (typeof n === 'number' ? String(n) : n);
 
 export const getKebabCase = (str?: string) => {
-    if (!str) return str;
+    if (!str || typeof str !== 'string') return str;
     return str
         .replace(/([a-z0-9])([A-Z])/g, '$1-$2') // get all lowercase letters that are near to uppercase ones
         .replace(/[\s]+/g, '-') // replace all spaces and low dash


### PR DESCRIPTION
This pull request makes small but important improvements to the `empty-trade-history-message` component and the `getKebabCase` utility function. The main changes enhance type safety and prevent potential runtime errors.

Component improvements:

* Made the `component_icon` prop in `TEmptyTradeHistoryMessage` optional, allowing the component to be used without requiring an icon.
* Updated the rendering logic in `EmptyTradeHistoryMessage` to only render the icon if `component_icon` is provided, preventing errors when the prop is absent.

Utility function robustness:

* Improved the `getKebabCase` function in `string_util.ts` to safely handle non-string inputs by returning the input unchanged if it is not a string, preventing unexpected behavior.