### PR TITLE
Farabi/grwt-6969/reports-active-tab-selector-issue

### DIFF
--- a/packages/reports/src/Constants/routes-config.tsx
+++ b/packages/reports/src/Constants/routes-config.tsx
@@ -8,7 +8,7 @@ import {
     LegacyStatementIcon,
 } from '@deriv/quill-icons';
 import { makeLazyLoader, moduleLoader, routes } from '@deriv/shared';
-import { Localize } from '@deriv-com/translations';
+import { localize } from '@deriv-com/translations';
 
 import type { TRoute, TRouteConfig } from 'Types';
 
@@ -26,26 +26,26 @@ const initRoutesConfig = (): TRouteConfig[] => {
             path: routes.reports,
             component: lazyLoadReportComponent('Reports'),
             is_authenticated: true,
-            getTitle: () => <Localize i18n_default_text='Reports' />,
+            getTitle: () => localize('Reports'),
             icon_component: <LegacyReportsIcon iconSize='xs' />,
             routes: [
                 {
                     path: routes.positions,
                     component: lazyLoadReportComponent('OpenPositions'),
-                    getTitle: () => <Localize i18n_default_text='Open positions' />,
+                    getTitle: () => localize('Open positions'),
                     icon_component: <LegacyOpenPositionIcon iconSize='xs' />,
                     default: true,
                 },
                 {
                     path: routes.profit,
                     component: lazyLoadReportComponent('ProfitTable'),
-                    getTitle: () => <Localize i18n_default_text='Trade table' />,
+                    getTitle: () => localize('Trade table'),
                     icon_component: <LegacyProfitTableIcon iconSize='xs' />,
                 },
                 {
                     path: routes.statement,
                     component: lazyLoadReportComponent('Statement'),
-                    getTitle: () => <Localize i18n_default_text='Statement' />,
+                    getTitle: () => localize('Statement'),
                     icon_component: <LegacyStatementIcon iconSize='xs' />,
                 },
             ],
@@ -56,7 +56,7 @@ const initRoutesConfig = (): TRouteConfig[] => {
 let routesConfig: TRouteConfig[];
 
 // For default page route if page/path is not found, must be kept at the end of routes_config array
-const route_default: TRoute = { component: Page404, getTitle: () => <Localize i18n_default_text='Error 404' /> };
+const route_default: TRoute = { component: Page404, getTitle: () => localize('Error 404') };
 
 const getRoutesConfig = (): TRouteConfig[] => {
     if (!routesConfig) {

--- a/packages/reports/src/Containers/reports.tsx
+++ b/packages/reports/src/Containers/reports.tsx
@@ -12,14 +12,6 @@ import { TRoute } from 'Types';
 
 import 'Sass/app/modules/reports.scss';
 
-type TList = {
-    value: React.ComponentType | typeof Redirect;
-    default?: boolean;
-    label: string;
-    icon?: React.ReactElement;
-    path?: string;
-};
-
 type TReports = {
     history: RouteComponentProps['history'];
     location: RouteComponentProps['location'];
@@ -32,7 +24,7 @@ const Reports = observer(({ history, location, routes }: TReports) => {
 
     const { is_logged_in, is_logging_in } = client;
     const { is_from_derivgo, routeBackInApp } = common;
-    const { is_reports_visible, setReportsTabIndex, reports_route_tab_index, toggleReports } = ui;
+    const { is_reports_visible, setReportsTabIndex, toggleReports } = ui;
     const { isDesktop } = useDevice();
 
     React.useEffect(() => {
@@ -62,19 +54,13 @@ const Reports = observer(({ history, location, routes }: TReports) => {
     const handleRouteChange = (e: React.ChangeEvent<HTMLSelectElement>) => history.push(e.target.value);
 
     const menu_options = () => {
-        const options: TList[] = [];
-
-        routes.forEach(route => {
-            options.push({
-                default: route.default,
-                icon: route.icon_component,
-                label: route.getTitle(),
-                value: route.component,
-                path: route.path,
-            });
-        });
-
-        return options;
+        return routes.map(route => ({
+            default: route.default,
+            icon: route.icon_component,
+            label: route.getTitle(),
+            value: route.component,
+            path: route.path,
+        }));
     };
 
     const selected_route = getSelectedRoute({ routes, pathname: location.pathname });
@@ -94,7 +80,6 @@ const Reports = observer(({ history, location, routes }: TReports) => {
                             is_routed
                             is_full_width
                             setVerticalTabIndex={setReportsTabIndex}
-                            vertical_tab_index={selected_route.default ? 0 : reports_route_tab_index}
                             list={menu_options()}
                         />
                     ) : (

--- a/packages/reports/src/Types/common-prop.type.ts
+++ b/packages/reports/src/Types/common-prop.type.ts
@@ -26,7 +26,7 @@ export type TRoute = {
     path?: string;
     component: React.ComponentType | typeof Redirect;
     is_authenticated?: boolean;
-    getTitle: () => string | React.ReactElement;
+    getTitle: () => string;
     icon_component?: React.ReactElement;
     routes?: TRoute[];
     default?: boolean;

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate-picker.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate-picker.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 import { Skeleton } from '@deriv/components';
 import { getGrowthRatePercentage } from '@deriv/shared';
 import { ActionSheet, Text, WheelPicker } from '@deriv-com/quill-ui';
-import { Localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import type { TV2ParamsInitialValues } from 'Stores/Modules/Trading/trade-store';
 
@@ -31,6 +31,7 @@ const GrowthRatePicker = ({
     should_show_details,
     tick_size_barrier_percentage,
 }: TGrowthRatePickerProps) => {
+    const { localize } = useTranslations();
     const initial_growth_rate = React.useRef<number>();
     const selected_growth_rate = React.useRef<number>(growth_rate);
     const data = accumulator_range_list.map(rate => ({ value: `${getGrowthRatePercentage(rate)}%` }));
@@ -41,7 +42,7 @@ const GrowthRatePicker = ({
         },
         {
             label: <Localize i18n_default_text='Max duration' />,
-            value: `${maximum_ticks || 0} ${maximum_ticks === 1 ? <Localize i18n_default_text='tick' /> : <Localize i18n_default_text='ticks' />}`,
+            value: `${maximum_ticks || 0} ${maximum_ticks === 1 ? localize('tick') : localize('ticks')}`,
         },
     ];
 


### PR DESCRIPTION
This pull request refactors localization usage in the reports and trader modules to improve consistency and simplify the codebase. The main changes include replacing the `Localize` component with the `localize` function for route titles, updating type definitions to reflect this change, and cleaning up unused code and props. Additionally, the trader module now uses the `useTranslations` hook for localization in the growth rate picker.

**Localization improvements in reports module:**

* Replaced the `Localize` component with the `localize` function for all route titles in `routes-config.tsx`, making titles plain strings instead of React elements. 
* Updated the `TRoute` type definition in `common-prop.type.ts` so `getTitle` returns a string instead of a string or React element.

**Code cleanup and simplification in reports module:**

* Removed the unused `TList` type and the `reports_route_tab_index` prop from `reports.tsx`.
* Simplified the `menu_options` function in `reports.tsx` to use `map` instead of manually building an array.
* Removed usage of `reports_route_tab_index` in the `VerticalTab` component props.

**Localization improvements in trader module:**

* Added the `useTranslations` hook and replaced the `Localize` component with the `localize` function for dynamic text in the growth rate picker.