### PR TITLE
Farabi/grwt-6972/rise-fall-missing-on-mobile

### DIFF
--- a/packages/trader/src/AppV2/Hooks/useContractsFor.ts
+++ b/packages/trader/src/AppV2/Hooks/useContractsFor.ts
@@ -161,11 +161,11 @@ const useContractsFor = () => {
                         if (contract.contract_category) {
                             // For Rise/Fall contracts with contract_category "callput"
                             if (contract.contract_category === 'callput' && key === 'rise_fall') {
-                                return isContractTypeMatch && contract_types[key].barrier_count === 1;
+                                return isContractTypeMatch;
                             }
                             // For Higher/Lower contracts with contract_category "higherlower"
                             if (contract.contract_category === 'higherlower' && key === 'high_low') {
-                                return isContractTypeMatch && contract_types[key].barrier_count === 1;
+                                return isContractTypeMatch;
                             }
                             // For other contract categories, use existing logic
                             return isContractTypeMatch;


### PR DESCRIPTION
This pull request updates the contract filtering logic in the `useContractsFor` hook to simplify how Rise/Fall and Higher/Lower contracts are matched. The change removes the requirement that these contract types must have a single barrier, making the matching criteria less restrictive.

Contract filtering logic simplification:

* In `useContractsFor.ts`, the checks for Rise/Fall (`callput`) and Higher/Lower (`higherlower`) contracts no longer require `barrier_count === 1`, and now only match based on contract type.