### PR TITLE
Farabi/grwt-6970/accumulatr-growth-rate-not-selected

### DIFF
--- a/packages/trader/src/App/Components/Form/number-selector.tsx
+++ b/packages/trader/src/App/Components/Form/number-selector.tsx
@@ -42,7 +42,7 @@ const NumberSelector = ({
                             <span
                                 key={i}
                                 className={classNames('number-selector__selection', {
-                                    'number-selector__selection--selected': selected_number === i,
+                                    'number-selector__selection--selected': Number(selected_number) === Number(i),
                                     'number-selector__selection--percentage': should_show_in_percents,
                                     'number-selector__selection--disabled': is_disabled,
                                 })}

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -749,10 +749,10 @@ export default class TradeStore extends BaseStore {
     setDefaultGrowthRate() {
         if (
             this.is_accumulator &&
-            !this.accumulator_range_list.includes(this.growth_rate) &&
+            !this.accumulator_range_list.map(Number).includes(Number(this.growth_rate)) &&
             this.accumulator_range_list.length
         ) {
-            this.growth_rate = this.accumulator_range_list[0];
+            this.growth_rate = Number(this.accumulator_range_list[0]);
         }
     }
 


### PR DESCRIPTION
This pull request addresses type consistency issues in the number selection and accumulator growth rate logic to prevent bugs caused by mismatched types. The changes ensure that number comparisons and assignments are always performed using numeric types.

Type consistency improvements:

* In `number-selector.tsx`, updated the selection logic to compare `selected_number` and `i` as numbers, preventing potential UI bugs when types mismatch.
* In `trade-store.ts`, ensured that both `accumulator_range_list` values and `growth_rate` are converted to numbers before comparison and assignment, improving reliability in the accumulator feature.