### PR TITLE
barrier not moving on websocket reconnection

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -54,6 +54,7 @@ export default class ClientStore extends BaseStore {
     website_status = {};
 
     has_cookie_account = false;
+    switch_broadcast = false;
 
     constructor(root_store) {
         const local_storage_properties = [];
@@ -127,6 +128,7 @@ export default class ClientStore extends BaseStore {
             clearSessionToken: action.bound,
             removeTokenFromUrl: action.bound,
             is_crypto: action.bound,
+            switch_broadcast: observable, // This is not to observe account changes, just to trigger reaction that listens to changes in the websoket connection status and login status
         });
 
         reaction(
@@ -553,6 +555,13 @@ export default class ClientStore extends BaseStore {
 
     setIsLoggingIn(bool) {
         this.is_logging_in = bool;
+    }
+    broadcastAccountChangeAfterAuthorize() {
+        this.switch_broadcast = true;
+    }
+
+    switchEndSignal() {
+        this.switch_broadcast = false;
     }
 
     setBalanceActiveAccount(obj_balance) {

--- a/packages/core/src/Stores/common-store.js
+++ b/packages/core/src/Stores/common-store.js
@@ -194,9 +194,14 @@ export default class CommonStore extends BaseStore {
     setIsSocketOpened(is_socket_opened) {
         // note that it's not for account switch that we're doing this,
         // but rather to reset account related stores like portfolio and contract-trade
+        const should_broadcast_account_change = this.was_socket_opened && is_socket_opened;
 
         this.is_socket_opened = is_socket_opened;
         this.was_socket_opened = this.was_socket_opened || is_socket_opened;
+
+        if (should_broadcast_account_change) {
+            this.root_store.client.broadcastAccountChangeAfterAuthorize();
+        }
     }
 
     setNetworkStatus(status, is_online) {

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -460,6 +460,8 @@ export type TClientStore = {
     responseWebsiteStatus: (response: any) => void;
     setIsPasskeySupported: (value: boolean) => void;
     init: () => Promise<boolean>;
+    switch_broadcast: boolean;
+    switchEndSignal: () => void;
 };
 
 type TCommonStoreError = {


### PR DESCRIPTION
This pull request introduces a new mechanism for broadcasting and reacting to account switches across the application's stores. The main changes center around adding a `switch_broadcast` observable and related methods to trigger and listen for account switch events, as well as providing a structured way for stores to register and dispose of account switch listeners. This improves the modularity and reliability of account switching logic, especially after socket reconnections.

**Account switch broadcasting and signaling:**

* Added `switch_broadcast` observable, `broadcastAccountChangeAfterAuthorize`, and `switchEndSignal` methods to `ClientStore` to trigger and reset account switch events. [[1]](diffhunk://#diff-ca1070ada988963eae4e734a9a2389b2fb4b76a0a6ffa3f2f0112e67e2ecb53cR57) [[2]](diffhunk://#diff-ca1070ada988963eae4e734a9a2389b2fb4b76a0a6ffa3f2f0112e67e2ecb53cR559-R565)
* Updated `CommonStore.setIsSocketOpened` to call `broadcastAccountChangeAfterAuthorize` when the socket is reopened, ensuring account switch events are broadcast after reconnection.
* Extended `TClientStore` type to include the new `switch_broadcast` and `switchEndSignal` members.

**Account switch listener management in stores:**

* Added `onSwitchAccount` and `disposeSwitchAccount` methods, and related properties, to `BaseStore` to allow stores to register asynchronous listeners for account switch events, and to manage their lifecycle cleanly. [[1]](diffhunk://#diff-d0c08e6a777b3257064bc94c1f4b08745dc1ebc3a49139bebc48cea12050cfe3R49-R50) [[2]](diffhunk://#diff-d0c08e6a777b3257064bc94c1f4b08745dc1ebc3a49139bebc48cea12050cfe3R84-R85) [[3]](diffhunk://#diff-d0c08e6a777b3257064bc94c1f4b08745dc1ebc3a49139bebc48cea12050cfe3L427-R465)
* Ensured `disposeSwitchAccount` is called during store unmounting to prevent memory leaks or unwanted listeners.