### PR TITLE
Farabi/fix--longcode-translation

### DIFF
--- a/packages/trader/src/AppV2/Components/PayoutInfo/payout-info.tsx
+++ b/packages/trader/src/AppV2/Components/PayoutInfo/payout-info.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { TContractInfo } from '@deriv/shared';
-import { Localize } from '@deriv-com/translations';
 import { Text } from '@deriv-com/quill-ui';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 import CardWrapper from 'AppV2/Components/CardWrapper';
 
@@ -10,10 +10,14 @@ interface ContractInfoProps {
     contract_info: TContractInfo;
 }
 
-const PayoutInfo = ({ contract_info }: ContractInfoProps) => (
-    <CardWrapper title={<Localize i18n_default_text='How do I earn a payout?' />}>
-        <Text size='sm'>{contract_info.longcode}</Text>
-    </CardWrapper>
-);
+const PayoutInfo = ({ contract_info }: ContractInfoProps) => {
+    const { localize } = useTranslations();
+
+    return (
+        <CardWrapper title={<Localize i18n_default_text='How do I earn a payout?' />}>
+            <Text size='sm'>{contract_info.longcode && localize(contract_info.longcode)}</Text>
+        </CardWrapper>
+    );
+};
 
 export default PayoutInfo;

--- a/packages/trader/src/Modules/Contract/Components/InfoBox/info-box-longcode.tsx
+++ b/packages/trader/src/Modules/Contract/Components/InfoBox/info-box-longcode.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Text } from '@deriv/components';
 import { LegacySellExpiredIcon } from '@deriv/quill-icons';
 import { isTabletOs, TContractInfo } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { Localize } from '@deriv-com/translations';
+import { Localize, useTranslations } from '@deriv-com/translations';
 
 type TInfoBoxLongcode = { contract_info: TContractInfo };
 
@@ -13,6 +13,7 @@ const InfoBoxLongcode = observer(({ contract_info }: TInfoBoxLongcode) => {
     const {
         ui: { is_mobile },
     } = useStore();
+    const { localize } = useTranslations();
     const max_longcode_length = is_mobile ? 47 : 150;
     const [is_collapsed, setIsCollapsed] = React.useState(true);
 
@@ -42,7 +43,7 @@ const InfoBoxLongcode = observer(({ contract_info }: TInfoBoxLongcode) => {
                         'info-box-longcode-text--collapsed--fixed-height': !isTabletOs && (is_collapsed || is_mobile),
                     })}
                 >
-                    {contract_info.longcode && <Localize i18n_default_text={contract_info.longcode} />}
+                    {contract_info.longcode && localize(contract_info.longcode)}
                 </Text>
                 {` `}
                 {contract_info?.longcode && contract_info.longcode.length > max_longcode_length && (
@@ -65,9 +66,7 @@ const InfoBoxLongcode = observer(({ contract_info }: TInfoBoxLongcode) => {
                 toggleModal={handleToggle}
             >
                 <Modal.Body>
-                    <Text size='xs'>
-                        {contract_info.longcode && <Localize i18n_default_text={contract_info.longcode} />}
-                    </Text>
+                    <Text size='xs'>{contract_info.longcode && localize(contract_info.longcode)}</Text>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button className='info-box-longcode--modal-button' primary large onClick={handleToggle}>


### PR DESCRIPTION
This pull request updates how contract longcode strings are localized in the `PayoutInfo` and `InfoBoxLongcode` components. Instead of rendering the longcode directly or using the `Localize` component, the code now uses the `localize` function from `useTranslations` to properly translate dynamic longcode strings.

**Localization improvements:**

* Updated `PayoutInfo` in `payout-info.tsx` to use the `localize` function from `useTranslations` for translating `contract_info.longcode` instead of the `Localize` component.
* Updated `InfoBoxLongcode` in `info-box-longcode.tsx` to use the `localize` function for all instances where `contract_info.longcode` is displayed, replacing the `Localize` component.