### PR TITLE
Akmal / feat: implement barrier reset logic on symbol change in TradeStore

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/__tests__/barrier-input.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/__tests__/barrier-input.spec.tsx
@@ -49,6 +49,23 @@ describe('BarrierInput', () => {
                 validation_errors: { barrier_1: [] },
                 duration: 10,
                 proposal_info: { CALL: { id: '123', message: 'test_message', has_error: true, spot: 12345 } },
+                symbol: '1HZ100V', // Synthetic symbol to show barrier chips
+                active_symbols: [
+                    {
+                        symbol: '1HZ100V',
+                        display_name: 'Volatility 100 (1s) Index',
+                        market: 'synthetic_index',
+                        symbol_type: 'synthetic_index',
+                        exchange_is_open: 1,
+                    },
+                    {
+                        symbol: 'EURUSD',
+                        display_name: 'EUR/USD',
+                        market: 'forex',
+                        symbol_type: 'forex',
+                        exchange_is_open: 1,
+                    },
+                ],
             },
         },
     };
@@ -92,13 +109,18 @@ describe('BarrierInput', () => {
         const belowSpotChip = screen.getByText('Below spot');
         const fixedPriceChip = screen.getByText('Fixed barrier');
 
+        // With staging pattern, onChange should not be called during chip selection
         await userEvent.click(belowSpotChip);
-        expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '-10' } });
+        expect(onChange).not.toHaveBeenCalled();
 
         await userEvent.click(fixedPriceChip);
-        expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '' } });
+        expect(onChange).not.toHaveBeenCalled();
 
         await userEvent.click(aboveSpotChip);
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '+10' } });
     });
 
@@ -106,12 +128,17 @@ describe('BarrierInput', () => {
         mockBarrierInput(mockStore(default_trade_store));
         const input = screen.getByPlaceholderText('Distance to spot');
 
+        // With staging pattern, onChange should not be called during input change
         fireEvent.change(input, { target: { value: '20' } });
-        expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '+20' } });
+        expect(onChange).not.toHaveBeenCalled();
 
         const belowSpotChip = screen.getByText('Below spot');
         await userEvent.click(belowSpotChip);
         fireEvent.change(input, { target: { value: '15' } });
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '-15' } });
     });
 
@@ -155,6 +182,11 @@ describe('BarrierInput', () => {
         const aboveSpotChip = screen.getByText('Above spot');
         await userEvent.click(aboveSpotChip);
 
+        // With staging pattern, onChange should not be called during chip selection
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '+10' } });
     });
 
@@ -165,6 +197,11 @@ describe('BarrierInput', () => {
         const belowSpotChip = screen.getByText('Below spot');
         await userEvent.click(belowSpotChip);
 
+        // With staging pattern, onChange should not be called during chip selection
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '-0.6' } });
     });
 
@@ -175,6 +212,11 @@ describe('BarrierInput', () => {
         const fixedPriceChip = screen.getByText('Fixed barrier');
         await userEvent.click(fixedPriceChip);
 
+        // With staging pattern, onChange should not be called during chip selection
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenCalledWith({ target: { name: 'barrier_1', value: '' } });
     });
 
@@ -185,6 +227,11 @@ describe('BarrierInput', () => {
         const aboveSpotChip = screen.getByText('Above spot');
         await userEvent.click(aboveSpotChip);
 
+        // With staging pattern, onChange should not be called during chip selection
+        expect(onChange).not.toHaveBeenCalled();
+
+        // onChange should only be called when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(onChange).toHaveBeenLastCalledWith({ target: { name: 'barrier_1', value: '+' } });
     });
 
@@ -203,12 +250,17 @@ describe('BarrierInput', () => {
         expect(screen.getAllByRole('button')[2]).toHaveAttribute('data-state', 'selected');
     });
 
-    it('stores barrier type in localStorage when chip is selected', async () => {
+    it('stores barrier type in localStorage when chip is selected and saved', async () => {
         mockBarrierInput(mockStore(default_trade_store));
 
         const fixedBarrierChip = screen.getByText('Fixed barrier');
         await userEvent.click(fixedBarrierChip);
 
+        // With staging pattern, localStorage should not be updated during chip selection
+        expect(localStorageMock.setItem).not.toHaveBeenCalledWith('deriv_barrier_type_selection', '2');
+
+        // localStorage should only be updated when Save is clicked
+        await userEvent.click(screen.getByText(/Save/));
         expect(localStorageMock.setItem).toHaveBeenCalledWith('deriv_barrier_type_selection', '2');
     });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/__tests__/barrier-input.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/__tests__/barrier-input.spec.tsx
@@ -66,6 +66,17 @@ describe('BarrierInput', () => {
                         exchange_is_open: 1,
                     },
                 ],
+                // Mock implementation of getSymbolBarrierSupport method
+                getSymbolBarrierSupport: jest.fn((symbol: string) => {
+                    if (!symbol) return 'absolute';
+
+                    // Return 'relative' for synthetic symbols, 'absolute' for forex
+                    if (symbol === '1HZ100V' || symbol.includes('HZ')) return 'relative';
+                    if (symbol === 'EURUSD' || symbol.includes('USD')) return 'absolute';
+
+                    // Default to absolute for unknown symbols
+                    return 'absolute';
+                }),
             },
         },
     };

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
@@ -34,10 +34,26 @@ const BarrierInput = observer(
             tick_data,
             setV2ParamsInitialValues,
             v2_params_initial_values,
+            symbol,
+            active_symbols,
         } = useTraderStore();
-        const [option, setOption] = React.useState(0);
         const [should_show_error, setShouldShowError] = React.useState(false);
         const { localize } = useTranslations();
+
+        // Draft state for staging changes until save
+        interface DraftState {
+            value: string;
+            type: number;
+            spotValue: string;
+            fixedValue: string;
+        }
+
+        const [draftState, setDraftState] = React.useState<DraftState>({
+            value: '',
+            type: 0,
+            spotValue: '',
+            fixedValue: '',
+        });
 
         // Constants for localStorage keys
         const SPOT_BARRIER_KEY = 'deriv_spot_barrier_value';
@@ -87,20 +103,84 @@ const BarrierInput = observer(
         const { pip_size } = tick_data ?? {};
         const barrier_ref = React.useRef<HTMLInputElement | null>(null);
         const show_hidden_error = validation_errors?.barrier_1.length > 0 && (barrier_1 || should_show_error);
+        const [previous_symbol, setPreviousSymbol] = React.useState(symbol);
 
+        // Helper function to determine barrier support for current symbol
+        const getSymbolBarrierSupport = React.useCallback((): 'relative' | 'absolute' => {
+            if (!symbol || !active_symbols.length) return 'absolute';
+
+            const symbol_info = active_symbols.find(s => ((s as any).underlying_symbol || s.symbol) === symbol);
+
+            if (!symbol_info) return 'absolute';
+
+            const market = symbol_info.market;
+            const symbol_type = (symbol_info as any).symbol_type;
+
+            // Forex symbols only support absolute barriers
+            if (market === 'forex' || symbol_type === 'forex') {
+                return 'absolute';
+            }
+
+            // Most other markets support relative barriers
+            return 'relative';
+        }, [symbol, active_symbols]);
+
+        // Effect to handle symbol changes and reset barrier type if needed
+        React.useEffect(() => {
+            if (symbol && previous_symbol && symbol !== previous_symbol) {
+                const barrier_support = getSymbolBarrierSupport();
+
+                // If switching to forex (absolute only), force fixed barrier option
+                if (barrier_support === 'absolute') {
+                    setDraftState(prev => ({ ...prev, type: 2 })); // Fixed barrier
+                    // Clear stored barrier type to prevent conflicts
+                    try {
+                        localStorage.removeItem(BARRIER_TYPE_KEY);
+                        localStorage.removeItem(SPOT_BARRIER_KEY);
+                    } catch {
+                        // Ignore localStorage errors
+                    }
+
+                    // Set a default barrier value if current barrier is empty or relative
+                    if (!barrier_1 || barrier_1.includes('+') || barrier_1.includes('-')) {
+                        const current_spot = tick_data?.quote;
+                        const default_barrier = current_spot ? (current_spot + 0.0001).toFixed(5) : '1.0000';
+                        onChange({ target: { name: 'barrier_1', value: default_barrier } });
+                        setV2ParamsInitialValues({ name: 'barrier_1', value: default_barrier });
+                        setFixedBarrierValue(default_barrier);
+                    }
+                }
+
+                setPreviousSymbol(symbol);
+            }
+        }, [
+            symbol,
+            previous_symbol,
+            getSymbolBarrierSupport,
+            barrier_1,
+            tick_data,
+            onChange,
+            setV2ParamsInitialValues,
+        ]);
+
+        // Initialize draft state when modal opens
         React.useEffect(() => {
             const initialValue = v2_params_initial_values?.barrier_1;
             const savedBarrierValue = String(initialValue || barrier_1);
             const storedBarrierType = getStoredBarrierType();
+            const barrier_support = getSymbolBarrierSupport();
 
             setInitialBarrierValue(savedBarrierValue);
             setV2ParamsInitialValues({ name: 'barrier_1', value: savedBarrierValue });
 
-            // Prioritize stored barrier type over value-based detection
+            // Determine barrier option based on symbol support and stored values
             let determinedOption: number;
 
-            if (storedBarrierType !== null && storedBarrierType >= 0 && storedBarrierType <= 2) {
-                // Use stored barrier type if available and valid
+            // For forex symbols, force fixed barrier regardless of stored values
+            if (barrier_support === 'absolute') {
+                determinedOption = 2; // Fixed barrier
+            } else if (storedBarrierType !== null && storedBarrierType >= 0 && storedBarrierType <= 2) {
+                // Use stored barrier type if available and valid for non-forex symbols
                 determinedOption = storedBarrierType;
             } else if (savedBarrierValue.includes('-')) {
                 determinedOption = 1; // Below spot
@@ -110,12 +190,14 @@ const BarrierInput = observer(
                 determinedOption = 2; // Fixed barrier
             }
 
-            setOption(determinedOption);
+            // Initialize draft state with current values
+            let spotValue = '';
+            let fixedValue = '';
 
-            // Initialize the appropriate barrier value based on the determined option
             if (determinedOption === 0 || determinedOption === 1) {
                 // Above/Below spot
                 const valueWithoutSign = savedBarrierValue.replace(/^[+-]/, '');
+                spotValue = valueWithoutSign;
                 setSpotBarrierValue(valueWithoutSign);
                 // Store in localStorage if not already there
                 if (!spot_barrier_value) {
@@ -123,6 +205,7 @@ const BarrierInput = observer(
                 }
             } else {
                 // Fixed barrier
+                fixedValue = savedBarrierValue;
                 setFixedBarrierValue(savedBarrierValue);
                 // Store in localStorage if not already there
                 if (!fixed_barrier_value) {
@@ -130,12 +213,21 @@ const BarrierInput = observer(
                 }
             }
 
-            // Store the determined barrier type for future use
-            storeBarrierType(determinedOption);
+            // Initialize draft state with all values
+            setDraftState({
+                value: savedBarrierValue,
+                type: determinedOption,
+                spotValue: spotValue || getStoredValue(SPOT_BARRIER_KEY),
+                fixedValue: fixedValue || getStoredValue(FIXED_BARRIER_KEY),
+            });
 
-            onChange({ target: { name: 'barrier_1', value: savedBarrierValue } });
+            // Store the determined barrier type for future use (only for non-forex)
+            if (barrier_support !== 'absolute') {
+                storeBarrierType(determinedOption);
+            }
+
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+        }, [getSymbolBarrierSupport]);
 
         React.useEffect(() => {
             const barrier_element = barrier_ref.current;
@@ -158,35 +250,27 @@ const BarrierInput = observer(
         }, [is_focused]);
 
         const handleChipSelect = (index: number) => {
-            const previousOption = option; // Store the previous option before updating
-            setOption(index);
-            let newValue = '';
+            const previousOption = draftState.type; // Store the previous option before updating
 
-            // Save current value to the appropriate state variable and localStorage
+            // Save current value to the appropriate draft state variable
             if (previousOption === 0 || previousOption === 1) {
-                // Coming from Above/Below spot, save to spot_barrier_value
-                const valueWithoutSign = barrier_1.replace(/^[+-]/, '');
-                setSpotBarrierValue(valueWithoutSign);
-                // Store in localStorage
-                storeValue(SPOT_BARRIER_KEY, valueWithoutSign);
+                // Coming from Above/Below spot, save to spotValue
+                const valueWithoutSign = draftState.value.replace(/^[+-]/, '');
+                setDraftState(prev => ({ ...prev, spotValue: valueWithoutSign }));
             } else if (previousOption === 2) {
-                // Coming from Fixed barrier, save to fixed_barrier_value
-                setFixedBarrierValue(barrier_1);
-                // Store in localStorage
-                storeValue(FIXED_BARRIER_KEY, barrier_1);
+                // Coming from Fixed barrier, save to fixedValue
+                setDraftState(prev => ({ ...prev, fixedValue: draftState.value }));
             }
 
-            // Store the new barrier type selection
-            storeBarrierType(index);
-
-            // Restore the appropriate value based on the tab we're switching to
+            // Determine the new value based on the tab we're switching to
+            let newValue = '';
             if (index === 0 || index === 1) {
                 // Switching to Above/Below spot
-                const valueToUse = spot_barrier_value || '';
+                const valueToUse = draftState.spotValue || '';
                 newValue = index === 0 ? `+${valueToUse}` : `-${valueToUse}`;
             } else if (index === 2) {
                 // Switching to Fixed barrier
-                newValue = fixed_barrier_value || '';
+                newValue = draftState.fixedValue || '';
             }
 
             if ((newValue.startsWith('+') || newValue.startsWith('-')) && newValue.charAt(1) === '.') {
@@ -195,43 +279,37 @@ const BarrierInput = observer(
                 newValue = `0${newValue}`;
             }
 
-            onChange({ target: { name: 'barrier_1', value: newValue } });
+            // Update draft state with new type and value
+            setDraftState(prev => ({ ...prev, type: index, value: newValue }));
         };
 
         const handleOnChange = (e: { target: { name: string; value: string } }) => {
             let value = e.target.value;
-            if (option === 0) value = `+${value}`;
-            if (option === 1) value = `-${value}`;
+            if (draftState.type === 0) value = `+${value}`;
+            if (draftState.type === 1) value = `-${value}`;
 
-            // Update the appropriate state variable based on the current tab
-            if (option === 0 || option === 1) {
+            // Update the appropriate draft state variable based on the current tab
+            if (draftState.type === 0 || draftState.type === 1) {
                 // Above/Below spot - store without sign
                 const valueWithoutSign = value.replace(/^[+-]/, '');
-                setSpotBarrierValue(valueWithoutSign);
-                // Store in localStorage
-                storeValue(SPOT_BARRIER_KEY, valueWithoutSign);
-            } else if (option === 2) {
+                setDraftState(prev => ({ ...prev, value, spotValue: valueWithoutSign }));
+            } else if (draftState.type === 2) {
                 // Fixed barrier
-                setFixedBarrierValue(value);
-                // Store in localStorage
-                storeValue(FIXED_BARRIER_KEY, value);
+                setDraftState(prev => ({ ...prev, value, fixedValue: value }));
             }
-
-            onChange({ target: { name: 'barrier_1', value } });
-            setV2ParamsInitialValues({ name: 'barrier_1', value });
         };
 
         return (
             <>
                 <ActionSheet.Content>
                     <div className='barrier-params'>
-                        {!isDays && (
+                        {!isDays && getSymbolBarrierSupport() === 'relative' && (
                             <div className='barrier-params__chips'>
                                 {chips_options.map((item, index) => (
                                     <Chip.Selectable
                                         key={index}
                                         onClick={() => handleChipSelect(index)}
-                                        selected={index == option}
+                                        selected={index == draftState.type}
                                     >
                                         <Text size='sm'>{item.name}</Text>
                                     </Chip.Selectable>
@@ -240,13 +318,13 @@ const BarrierInput = observer(
                         )}
 
                         <div>
-                            {option === 2 || isDays ? (
+                            {draftState.type === 2 || isDays ? (
                                 <TextField
                                     customType='commaRemoval'
                                     name='barrier_1'
                                     noStatusIcon
                                     status={show_hidden_error ? 'error' : 'neutral'}
-                                    value={barrier_1}
+                                    value={draftState.value}
                                     allowDecimals
                                     decimals={pip_size}
                                     allowSign={false}
@@ -265,9 +343,9 @@ const BarrierInput = observer(
                                     customType='commaRemoval'
                                     name='barrier_1'
                                     noStatusIcon
-                                    addonLabel={option == 0 ? '+' : '-'}
+                                    addonLabel={draftState.type == 0 ? '+' : '-'}
                                     decimals={pip_size}
-                                    value={barrier_1.replace(/[+-]/g, '')}
+                                    value={draftState.value.replace(/[+-]/g, '')}
                                     allowDecimals
                                     inputMode='decimal'
                                     allowSign={false}
@@ -299,23 +377,21 @@ const BarrierInput = observer(
                         content: <Localize i18n_default_text='Save' />,
                         onAction: () => {
                             if (validation_errors.barrier_1.length === 0) {
-                                // Save the current values to localStorage before closing
-                                if (option === 0 || option === 1) {
-                                    const valueWithoutSign = barrier_1.replace(/^[+-]/, '');
-                                    storeValue(SPOT_BARRIER_KEY, valueWithoutSign);
-                                } else if (option === 2) {
-                                    storeValue(FIXED_BARRIER_KEY, barrier_1);
+                                // Apply draft changes to store
+                                onChange({ target: { name: 'barrier_1', value: draftState.value } });
+                                setV2ParamsInitialValues({ name: 'barrier_1', value: draftState.value });
+
+                                // Save the current values to localStorage
+                                if (draftState.type === 0 || draftState.type === 1) {
+                                    storeValue(SPOT_BARRIER_KEY, draftState.spotValue);
+                                } else if (draftState.type === 2) {
+                                    storeValue(FIXED_BARRIER_KEY, draftState.fixedValue);
                                 }
 
                                 // Save the current barrier type selection
-                                storeBarrierType(option);
+                                storeBarrierType(draftState.type);
 
                                 onClose(true);
-
-                                // This is a workaround to re-trigger any validation errors that were hidden behind the action sheet
-                                handleOnChange({
-                                    target: { name: 'barrier_1', value: barrier_1.replace(/[+-]/g, '') },
-                                });
                             } else {
                                 setShouldShowError(true);
                             }

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
@@ -84,18 +84,32 @@ const Barrier = observer(({ is_minimized }: TTradeParametersProps) => {
         }
     }, [v2_params_initial_values.barrier_1, barrier_1, getStoredBarrierValue, setV2ParamsInitialValues, onChange]);
 
+    // Sync v2_params_initial_values with barrier_1 when barrier_1 changes (e.g., from symbol reset)
+    React.useEffect(() => {
+        // If barrier_1 has a value but v2_params_initial_values.barrier_1 is empty, sync them
+        if (barrier_1 && !v2_params_initial_values.barrier_1) {
+            setV2ParamsInitialValues({ value: barrier_1, name: 'barrier_1' });
+        }
+        // If barrier_1 changes and is different from v2_params_initial_values.barrier_1, update display
+        // This handles cases where the store value was reset but the display value wasn't updated
+        else if (
+            barrier_1 &&
+            v2_params_initial_values.barrier_1 &&
+            barrier_1 !== String(v2_params_initial_values.barrier_1)
+        ) {
+            setV2ParamsInitialValues({ value: barrier_1, name: 'barrier_1' });
+        }
+    }, [barrier_1, v2_params_initial_values.barrier_1, setV2ParamsInitialValues]);
+
     const onClose = React.useCallback(
         (is_saved = false) => {
             if (is_open) {
-                if (!is_saved) {
-                    onChange({ target: { name: 'barrier_1', value: initialBarrierValue } });
-                }
                 setV2ParamsInitialValues({ value: '', name: 'barrier_1' });
                 setIsOpen(false);
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [initialBarrierValue, is_open]
+        [is_open]
     );
 
     React.useEffect(() => {

--- a/packages/trader/src/Stores/Modules/Trading/__tests__/barrier-reset.spec.ts
+++ b/packages/trader/src/Stores/Modules/Trading/__tests__/barrier-reset.spec.ts
@@ -110,18 +110,28 @@ describe('TradeStore - Barrier Reset on Symbol Change', () => {
 
     describe('getSymbolBarrierSupport', () => {
         it('should return "absolute" for forex symbols', () => {
-            const result = (trade_store as any).getSymbolBarrierSupport('EURUSD');
+            const result = trade_store.getSymbolBarrierSupport('EURUSD');
             expect(result).toBe('absolute');
         });
 
         it('should return "relative" for synthetic symbols', () => {
-            const result = (trade_store as any).getSymbolBarrierSupport('1HZ100V');
+            const result = trade_store.getSymbolBarrierSupport('1HZ100V');
             expect(result).toBe('relative');
         });
 
         it('should return "absolute" for unknown symbols', () => {
-            const result = (trade_store as any).getSymbolBarrierSupport('UNKNOWN');
+            const result = trade_store.getSymbolBarrierSupport('UNKNOWN');
             expect(result).toBe('absolute');
+        });
+
+        it('should be accessible as public method for component usage', () => {
+            // Test that the method is now public and accessible from components
+            expect(typeof trade_store.getSymbolBarrierSupport).toBe('function');
+
+            // Test that it works correctly when called from external components
+            expect(trade_store.getSymbolBarrierSupport('EURUSD')).toBe('absolute');
+            expect(trade_store.getSymbolBarrierSupport('1HZ100V')).toBe('relative');
+            expect(trade_store.getSymbolBarrierSupport('')).toBe('absolute');
         });
     });
 

--- a/packages/trader/src/Stores/Modules/Trading/__tests__/barrier-reset.spec.ts
+++ b/packages/trader/src/Stores/Modules/Trading/__tests__/barrier-reset.spec.ts
@@ -1,0 +1,297 @@
+import { configure } from 'mobx';
+import { mockStore } from '@deriv/stores';
+import TradeStore from '../trade-store';
+import { TRootStore } from 'Types';
+
+configure({ safeDescriptors: false });
+
+// Mock localStorage
+const localStorageMock = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+});
+
+// Mock shared utilities
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    pickDefaultSymbol: jest.fn(() => Promise.resolve('1HZ100V')),
+    isMarketClosed: jest.fn(() => false),
+    WS: {
+        authorized: {
+            activeSymbols: () => Promise.resolve({ active_symbols: [] }),
+        },
+        contractsFor: () => Promise.resolve({ contracts_for: { available: [], non_available: [] } }),
+        storage: {
+            contractsFor: () => Promise.resolve({ contracts_for: { available: [], non_available: [] } }),
+        },
+        subscribeProposal: jest.fn(),
+        forgetAll: jest.fn(),
+        wait: jest.fn(() => Promise.resolve({})),
+    },
+}));
+
+// Mock process helpers
+jest.mock('../Helpers/process', () => ({
+    processContractsForApi: jest.fn(() => Promise.resolve()),
+    processPurchase: jest.fn(() => Promise.resolve()),
+    processProposal: jest.fn(() => Promise.resolve()),
+    processTradeParams: jest.fn(() => Promise.resolve()),
+}));
+
+describe('TradeStore - Barrier Reset on Symbol Change', () => {
+    let trade_store: TradeStore, mockRootStore: TRootStore;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        localStorageMock.getItem.mockReturnValue(null);
+
+        mockRootStore = mockStore({
+            ui: {
+                is_mobile: true,
+                advanced_expiry_type: 'duration',
+                simple_duration_unit: 'm',
+                advanced_duration_unit: 'm',
+                is_advanced_duration: false,
+            },
+            client: {
+                currency: 'USD',
+                default_currency: 'USD',
+                is_logged_in: false,
+                is_logging_in: false,
+            },
+            common: {
+                current_language: 'en',
+                showError: jest.fn(),
+                setSelectedContractType: jest.fn(),
+            },
+            portfolio: {
+                setContractType: jest.fn(),
+                barriers: [],
+            },
+            notifications: {
+                removeTradeNotifications: jest.fn(),
+            },
+            contract_trade: {
+                clearAccumulatorBarriersData: jest.fn(),
+            },
+            active_symbols: {
+                setActiveSymbols: jest.fn(),
+            },
+        }) as unknown as TRootStore;
+
+        trade_store = new TradeStore({ root_store: mockRootStore });
+
+        // Mock active symbols with forex and synthetic symbols
+        trade_store.active_symbols = [
+            {
+                symbol: 'EURUSD',
+                display_name: 'EUR/USD',
+                market: 'forex',
+                symbol_type: 'forex',
+                exchange_is_open: 1,
+            },
+            {
+                symbol: '1HZ100V',
+                display_name: 'Volatility 100 (1s) Index',
+                market: 'synthetic_index',
+                symbol_type: 'synthetic_index',
+                exchange_is_open: 1,
+            },
+        ] as any;
+
+        // Set up initial state using actions to avoid MobX warnings
+        trade_store.updateStore({ symbol: '1HZ100V', barrier_1: '+1.17' });
+    });
+
+    describe('getSymbolBarrierSupport', () => {
+        it('should return "absolute" for forex symbols', () => {
+            const result = (trade_store as any).getSymbolBarrierSupport('EURUSD');
+            expect(result).toBe('absolute');
+        });
+
+        it('should return "relative" for synthetic symbols', () => {
+            const result = (trade_store as any).getSymbolBarrierSupport('1HZ100V');
+            expect(result).toBe('relative');
+        });
+
+        it('should return "absolute" for unknown symbols', () => {
+            const result = (trade_store as any).getSymbolBarrierSupport('UNKNOWN');
+            expect(result).toBe('absolute');
+        });
+    });
+
+    describe('getSymbolDurationSupport', () => {
+        it('should return "endtime" for forex symbols', () => {
+            const result = (trade_store as any).getSymbolDurationSupport('EURUSD');
+            expect(result).toBe('endtime');
+        });
+
+        it('should return "ticks" for synthetic symbols', () => {
+            const result = (trade_store as any).getSymbolDurationSupport('1HZ100V');
+            expect(result).toBe('ticks');
+        });
+
+        it('should return "endtime" for unknown symbols', () => {
+            const result = (trade_store as any).getSymbolDurationSupport('UNKNOWN');
+            expect(result).toBe('endtime');
+        });
+    });
+
+    describe('handleTradeParamsResetOnSymbolChange', () => {
+        it('should reset barriers when switching from synthetic to forex', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', 'EURUSD');
+
+            // Should return barrier and duration reset values for forex
+            expect(result).toEqual({
+                barrier_1: '1.0000', // Default when no tick data available
+                barrier_2: '',
+                duration: 5,
+                duration_unit: 'm',
+                expiry_type: 'endtime',
+            });
+
+            // Should clear localStorage
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_spot_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_fixed_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_barrier_type_selection');
+        });
+
+        it('should reset barriers with spot-based value when tick data is available', () => {
+            // Set up tick data
+            trade_store.setTickData({ quote: 1.2345, pip_size: 5 });
+
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', 'EURUSD');
+
+            // Should return barrier and duration reset values with spot-based barrier
+            expect(result).toEqual({
+                barrier_1: '1.23460', // spot + pip_size increment
+                barrier_2: '',
+                duration: 5,
+                duration_unit: 'm',
+                expiry_type: 'endtime',
+            });
+        });
+
+        it('should reset barriers when switching from forex to synthetic', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('EURUSD', '1HZ100V');
+
+            expect(result).toEqual({
+                barrier_1: '+0.1',
+                barrier_2: '',
+                duration: 5,
+                duration_unit: 't',
+                expiry_date: null,
+                expiry_time: null,
+                expiry_type: 'duration',
+            });
+
+            // Should clear localStorage
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_spot_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_fixed_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_barrier_type_selection');
+        });
+
+        it('should not reset barriers when switching between symbols with same barrier support', () => {
+            // Add another synthetic symbol to active_symbols for this test
+            trade_store.active_symbols.push({
+                symbol: '1HZ200V',
+                display_name: 'Volatility 200 (1s) Index',
+                market: 'synthetic_index',
+                symbol_type: 'synthetic_index',
+                exchange_is_open: 1,
+            } as any);
+
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', '1HZ200V');
+
+            expect(result).toBeNull();
+            expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+        });
+
+        it('should return null for same symbol', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('EURUSD', 'EURUSD');
+
+            expect(result).toBeNull();
+            expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+        });
+
+        it('should return null for empty symbols', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('', 'EURUSD');
+
+            expect(result).toBeNull();
+            expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+        });
+
+        it('should reset UI store duration units when switching from synthetic to forex', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', 'EURUSD');
+
+            // Should have reset UI store duration units to minutes for forex
+            expect(mockRootStore.ui.advanced_duration_unit).toBe('m');
+            expect(mockRootStore.ui.simple_duration_unit).toBe('m');
+        });
+
+        it('should reset UI store duration units when switching from forex to synthetic', () => {
+            const result = trade_store.handleTradeParamsResetOnSymbolChange('EURUSD', '1HZ100V');
+
+            // Should have reset UI store duration units to ticks for synthetic
+            expect(mockRootStore.ui.advanced_duration_unit).toBe('t');
+            expect(mockRootStore.ui.simple_duration_unit).toBe('t');
+        });
+
+        it('should clear all localStorage keys when switching markets', () => {
+            trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', 'EURUSD');
+
+            // Should clear all barrier-related localStorage keys
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_spot_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_fixed_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_barrier_type_selection');
+
+            // Verify that localStorage.removeItem was called multiple times (for all the keys)
+            expect(localStorageMock.removeItem).toHaveBeenCalledTimes(11);
+        });
+
+        it('should clear v2_params_initial_values for barrier and duration fields', () => {
+            // Set up some initial values
+            trade_store.v2_params_initial_values = {
+                barrier_1: 1.5,
+                duration: 10,
+                duration_unit: 't',
+                expiry_type: 'duration',
+                other_field: 'should_remain',
+            } as any;
+
+            trade_store.handleTradeParamsResetOnSymbolChange('1HZ100V', 'EURUSD');
+
+            // Should clear all v2_params_initial_values (the implementation clears everything)
+            expect(trade_store.v2_params_initial_values).toEqual({});
+        });
+    });
+
+    describe('processNewValuesAsync integration', () => {
+        it('should apply barrier reset when symbol changes in processNewValuesAsync', async () => {
+            // Set up initial state with synthetic symbol and relative barrier using actions
+            trade_store.updateStore({ symbol: '1HZ100V', barrier_1: '+1.17' });
+
+            // Mock the is_dtrader_v2 getter to return true by modifying the root store
+            mockRootStore.ui.is_mobile = true;
+
+            // Spy on the barrier reset method
+            const handleTradeParamsResetSpy = jest.spyOn(trade_store, 'handleTradeParamsResetOnSymbolChange');
+
+            // Process symbol change to forex
+            await trade_store.processNewValuesAsync({ symbol: 'EURUSD' }, true);
+
+            // Should have called the barrier reset method
+            expect(handleTradeParamsResetSpy).toHaveBeenCalledWith('1HZ100V', 'EURUSD');
+
+            // Should have cleared localStorage
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_spot_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_fixed_barrier_value');
+            expect(localStorageMock.removeItem).toHaveBeenCalledWith('deriv_barrier_type_selection');
+        });
+    });
+});

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -2356,7 +2356,7 @@ export default class TradeStore extends BaseStore {
      * @param symbol - The symbol to check
      * @returns 'relative' for synthetic indices, 'absolute' for forex markets
      */
-    private getSymbolBarrierSupport(symbol: string): BarrierSupportType {
+    public getSymbolBarrierSupport(symbol: string): BarrierSupportType {
         if (!symbol || !this.active_symbols.length) return 'absolute';
 
         const symbol_info = this.active_symbols.find(s => ((s as any).underlying_symbol || s.symbol) === symbol);


### PR DESCRIPTION
- Added handleTradeParamsResetOnSymbolChange method to reset barriers and duration based on symbol support.
- Updated validation error handling for barriers during symbol changes.
- Enhanced localStorage management for barrier and duration values when switching between symbols.
- Introduced helper methods to determine symbol barrier and duration support.
- Added tests for barrier reset functionality in TradeStore.
