### PR TITLE
Farabi/grwt-7094/fix-account-header

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/__tests__/account-actions.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/account-actions.spec.tsx
@@ -60,18 +60,16 @@ jest.mock('App/Components/Layout/Header/account-info.jsx', () => ({
     __esModule: true,
     default: ({
         balance,
-        is_virtual,
         currency,
         is_dialog_on,
         toggleDialog,
     }: {
         balance?: string | number;
-        is_virtual?: boolean;
         currency?: string;
         is_dialog_on?: boolean;
         toggleDialog?: () => void;
     }) => (
-        <div data-testid='dt_account_info' onClick={toggleDialog} className={`${is_virtual ? 'virtual' : ''}`}>
+        <div data-testid='dt_account_info' onClick={toggleDialog}>
             Account Info: {balance} {currency} {is_dialog_on ? 'open' : 'closed'}
         </div>
     ),
@@ -84,18 +82,16 @@ jest.mock(
         __esModule: true,
         default: ({
             balance,
-            is_virtual,
             currency,
             is_dialog_on,
             toggleDialog,
         }: {
             balance?: string | number;
-            is_virtual?: boolean;
             currency?: string;
             is_dialog_on?: boolean;
             toggleDialog?: () => void;
         }) => (
-            <div data-testid='dt_account_info' onClick={toggleDialog} className={`${is_virtual ? 'virtual' : ''}`}>
+            <div data-testid='dt_account_info' onClick={toggleDialog}>
                 Account Info: {balance} {currency} {is_dialog_on ? 'open' : 'closed'}
             </div>
         ),
@@ -109,7 +105,6 @@ describe('AccountActions component', () => {
         balance: 1000,
         currency: 'USD',
         is_logged_in: true,
-        is_virtual: false,
         onClickLogout: jest.fn(),
     };
 

--- a/packages/core/src/App/Components/Layout/Header/__tests__/account-info-icon.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/account-info-icon.spec.tsx
@@ -8,17 +8,17 @@ describe('AccountInfoIcon component', () => {
         expect(screen.queryByTestId('dt_icon')).toBeInTheDocument();
     });
 
-    it('should render icon for virtual', () => {
-        render(<AccountInfoIcon is_virtual={true} currency='usd' />);
+    it('should render icon for demo', () => {
+        render(<AccountInfoIcon is_demo={true} currency='usd' />);
         const icon = screen.queryByTestId('dt_icon');
-        expect(icon).toHaveClass('acc-info__id-icon--virtual');
+        expect(icon).toHaveClass('acc-info__id-icon--demo');
         expect(icon).not.toHaveClass('acc-info__id-icon--usd');
     });
 
-    it('should render icon for not virtual and usd currency', () => {
+    it('should render icon for not demo and usd currency', () => {
         render(<AccountInfoIcon currency='usd' />);
         const icon = screen.queryByTestId('dt_icon');
         expect(icon).toHaveClass('acc-info__id-icon--usd');
-        expect(icon).not.toHaveClass('acc-info__id-icon--virtual');
+        expect(icon).not.toHaveClass('acc-info__id-icon--demo');
     });
 });

--- a/packages/core/src/App/Components/Layout/Header/__tests__/account-info.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/account-info.spec.tsx
@@ -1,43 +1,64 @@
 import React from 'react';
 
+import { getAccountTypeFromUrl } from '@deriv/shared';
 import { render, screen } from '@testing-library/react';
 
 import AccountInfo from '../account-info.jsx';
 
+// Mock the getAccountTypeFromUrl function
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    getAccountTypeFromUrl: jest.fn(),
+}));
+
+const mockGetAccountTypeFromUrl = getAccountTypeFromUrl as jest.MockedFunction<typeof getAccountTypeFromUrl>;
+
 describe('AccountInfo component', () => {
-    it('should have "acc-info--is-virtual" class when "is_virtual" property is "true"', () => {
-        render(<AccountInfo is_virtual />);
+    beforeEach(() => {
+        // Reset the mock before each test
+        mockGetAccountTypeFromUrl.mockReset();
+    });
+
+    it('should have "acc-info--is-demo" class when account_type is "demo"', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        render(<AccountInfo />);
         const div_element = screen.getByTestId('dt_acc_info');
-        expect(div_element).toHaveClass('acc-info--is-virtual');
+        expect(div_element).toHaveClass('acc-info--is-demo');
     });
 
     it('should render "AccountInfoIcon" with the proper className', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
         const { rerender } = render(<AccountInfo currency='USD' />);
         expect(screen.getByTestId('dt_icon')).toHaveClass('acc-info__id-icon--usd');
 
-        rerender(<AccountInfo is_virtual />);
-        expect(screen.getByTestId('dt_icon')).toHaveClass('acc-info__id-icon--virtual');
+        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        rerender(<AccountInfo />);
+        expect(screen.getByTestId('dt_icon')).toHaveClass('acc-info__id-icon--demo');
     });
 
     it('should not render balance section when "currency" property passed', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
         render(<AccountInfo currency='USD' />);
         const balance_wrapper = screen.queryByTestId('dt_balance');
         expect(balance_wrapper).not.toBeInTheDocument();
     });
 
-    it('should have "acc-info__balance--no-currency" class when "is_virtual" property is "false" and we don\'t have "currency" property', () => {
+    it('should have "acc-info__balance--no-currency" class when account is real and we don\'t have "currency" property', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
         render(<AccountInfo />);
         const balance_wrapper = screen.getByTestId('dt_balance');
         expect(balance_wrapper).toHaveClass('acc-info__balance--no-currency');
     });
 
     it('should have "No currency assigned" text when we don\'t have "currency" property', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
         render(<AccountInfo />);
         const text = screen.getByText(/no currency assigned/i);
         expect(text).toBeInTheDocument();
     });
 
     it('should have "123456789 USD" text when we have "currency" and "balance" properties', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
         render(<AccountInfo currency='USD' balance='123456789' />);
         const text = screen.getByText(/123456789 usd/i);
         expect(text).toBeInTheDocument();
@@ -45,21 +66,24 @@ describe('AccountInfo component', () => {
     });
 
     it('should display "Real" account type label for real accounts', () => {
-        render(<AccountInfo is_virtual={false} currency='USD' balance='1000' />);
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Real');
         expect(accountTypeLabel).toBeInTheDocument();
         expect(accountTypeLabel).toHaveClass('acc-info__account-type');
     });
 
-    it('should display "Demo" account type label for virtual accounts', () => {
-        render(<AccountInfo is_virtual={true} currency='USD' balance='1000' />);
+    it('should display "Demo" account type label for demo accounts', () => {
+        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Demo');
         expect(accountTypeLabel).toBeInTheDocument();
         expect(accountTypeLabel).toHaveClass('acc-info__account-type');
     });
 
     it('should display account type label in header section when currency is assigned', () => {
-        render(<AccountInfo is_virtual={false} currency='USD' balance='1000' />);
+        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Real');
         const balanceElement = screen.getByText(/1000 usd/i);
 

--- a/packages/core/src/App/Components/Layout/Header/account-actions.tsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.tsx
@@ -13,7 +13,6 @@ type TAccountActionsProps = {
     balance: string | number | undefined;
     currency: string;
     is_logged_in: boolean;
-    is_virtual: boolean;
     onClickLogout: () => void;
 };
 
@@ -35,13 +34,7 @@ const LoggedOutView = () => (
     </>
 );
 
-const AccountActionsComponent = ({
-    balance,
-    currency,
-    is_logged_in,
-    is_virtual,
-    onClickLogout,
-}: TAccountActionsProps) => {
+const AccountActionsComponent = ({ balance, currency, is_logged_in, onClickLogout }: TAccountActionsProps) => {
     const { isDesktop } = useDevice();
     const isLogoutButtonVisible = isDesktop && is_logged_in;
     const formattedBalance = balance != null ? formatMoney(currency, balance, true) : undefined;
@@ -51,7 +44,6 @@ const AccountActionsComponent = ({
             <AccountInfo
                 balance={formattedBalance}
                 currency={currency}
-                is_virtual={is_virtual}
                 {...(!isDesktop && {
                     is_mobile: true,
                 })}

--- a/packages/core/src/App/Components/Layout/Header/account-info-icon.tsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info-icon.tsx
@@ -13,7 +13,7 @@ import {
 } from '@deriv/quill-icons';
 
 type TAccountInfoIcon = {
-    is_virtual?: boolean;
+    is_demo?: boolean;
     currency?: string;
 };
 
@@ -26,18 +26,18 @@ const currencyIconMap: { [key: string]: React.ComponentType<any> } = {
     eth: CurrencyEthIcon,
     ltc: CurrencyLtcIcon,
     ust: CurrencyUsdtIcon,
-    virtual: CurrencyDemoIcon,
+    demo: CurrencyDemoIcon,
     Unknown: CurrencyNoneIcon,
 };
 
-const AccountInfoIcon = ({ is_virtual, currency }: TAccountInfoIcon) => {
-    const currencyKey = is_virtual ? 'virtual' : (currency ?? 'Unknown');
+const AccountInfoIcon = ({ is_demo, currency }: TAccountInfoIcon) => {
+    const currencyKey = is_demo ? 'demo' : (currency ?? 'Unknown');
     const IconComponent = currencyIconMap[currencyKey] || CurrencyNoneIcon;
 
     return (
         <IconComponent
             data-testid='dt_icon'
-            className={`acc-info__id-icon acc-info__id-icon--${is_virtual ? 'virtual' : currency}`}
+            className={`acc-info__id-icon acc-info__id-icon--${is_demo ? 'demo' : currency}`}
             iconSize='sm'
         />
     );

--- a/packages/core/src/App/Components/Layout/Header/account-info.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info.jsx
@@ -10,13 +10,14 @@ import { useDevice } from '@deriv-com/ui';
 import AccountInfoIcon from './account-info-icon';
 import AccountInfoWrapper from './account-info-wrapper';
 
-const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
+const AccountInfo = ({ balance, currency, is_mobile }) => {
     const { localize } = useTranslations();
     const currency_lower = currency?.toLowerCase();
     const { isDesktop } = useDevice();
 
     const accountTypeFromUrl = getAccountTypeFromUrl();
     const accountTypeHeader = accountTypeFromUrl === 'real' ? localize('Real') : localize('Demo');
+    const isDemoAccount = accountTypeFromUrl === 'demo';
 
     return (
         <div className='acc-info__wrapper'>
@@ -26,15 +27,15 @@ const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
                     data-testid='dt_acc_info'
                     id='dt_core_account-info_acc-info'
                     className={classNames('acc-info', {
-                        'acc-info--is-virtual': is_virtual,
+                        'acc-info--is-demo': isDemoAccount,
                     })}
                 >
                     <span className='acc-info__id'>
                         {isDesktop ? (
-                            <AccountInfoIcon is_virtual={is_virtual} currency={currency_lower} />
+                            <AccountInfoIcon is_demo={isDemoAccount} currency={currency_lower} />
                         ) : (
-                            (is_virtual || currency) && (
-                                <AccountInfoIcon is_virtual={is_virtual} currency={currency_lower} />
+                            (isDemoAccount || currency) && (
+                                <AccountInfoIcon is_demo={isDemoAccount} currency={currency_lower} />
                             )
                         )}
                     </span>
@@ -49,7 +50,7 @@ const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
                                 <p
                                     data-testid='dt_balance'
                                     className={classNames('acc-info__balance', {
-                                        'acc-info__balance--no-currency': !currency && !is_virtual,
+                                        'acc-info__balance--no-currency': !currency && !isDemoAccount,
                                     })}
                                 >
                                     {!currency ? (
@@ -71,7 +72,6 @@ const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
 AccountInfo.propTypes = {
     balance: PropTypes.string,
     currency: PropTypes.string,
-    is_virtual: PropTypes.bool,
     is_mobile: PropTypes.bool,
 };
 

--- a/packages/core/src/App/Components/Layout/Header/account-info.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { Text } from '@deriv/components';
-import { getCurrencyDisplayCode } from '@deriv/shared';
+import { getAccountTypeFromUrl, getCurrencyDisplayCode } from '@deriv/shared';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
@@ -14,6 +14,9 @@ const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
     const { localize } = useTranslations();
     const currency_lower = currency?.toLowerCase();
     const { isDesktop } = useDevice();
+
+    const accountTypeFromUrl = getAccountTypeFromUrl();
+    const accountTypeHeader = accountTypeFromUrl === 'real' ? localize('Real') : localize('Demo');
 
     return (
         <div className='acc-info__wrapper'>
@@ -38,7 +41,7 @@ const AccountInfo = ({ balance, currency, is_virtual, is_mobile }) => {
                     <div className='acc-info__content'>
                         <div className='acc-info__account-type-header'>
                             <Text as='p' size='xxs' className='acc-info__account-type'>
-                                {is_virtual ? localize('Demo') : localize('Real')}
+                                {accountTypeHeader}
                             </Text>
                         </div>
                         {(typeof balance !== 'undefined' || !currency) && (

--- a/packages/core/src/App/Containers/Layout/header/header-account-actions.tsx
+++ b/packages/core/src/App/Containers/Layout/header/header-account-actions.tsx
@@ -6,7 +6,7 @@ import { AccountActions } from 'App/Components/Layout/Header';
 
 const HeaderAccountActions = observer(() => {
     const { client } = useStore();
-    const { balance, currency, is_logged_in, is_virtual, logout } = client;
+    const { balance, currency, is_logged_in, logout } = client;
 
     const handleLogout = () => {
         logout();
@@ -18,7 +18,6 @@ const HeaderAccountActions = observer(() => {
                 balance={balance}
                 currency={currency}
                 is_logged_in={is_logged_in}
-                is_virtual={is_virtual}
                 onClickLogout={handleLogout}
             />
         </div>

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -120,7 +120,7 @@
         }
     }
 
-    &--is-virtual {
+    &--is-demo {
         .acc-info__balance {
             color: var(--color-text-success);
         }


### PR DESCRIPTION
This pull request refactors the way account types are handled in the header components, replacing the use of the `is_virtual` prop with a more robust account type detection using `getAccountTypeFromUrl`. The changes standardize the terminology from "virtual" to "demo" throughout the codebase and improve test reliability by mocking account type detection. This enhances maintainability and prepares the code for future account type expansions.

**Account type handling improvements:**

* Replaced the `is_virtual` prop with account type detection via `getAccountTypeFromUrl` in `AccountInfo` and related components, ensuring account type is determined centrally and consistently. (`packages/core/src/App/Components/Layout/Header/account-info.jsx`
* Updated tests to mock `getAccountTypeFromUrl`, improving test reliability and removing direct reliance on the `is_virtual` prop. (`packages/core/src/App/Components/Layout/Header/__tests__/account-info.spec.tsx`

**Terminology standardization:**

* Renamed all references and CSS classes from "virtual" to "demo" (e.g., `acc-info--is-virtual` to `acc-info--is-demo`, and icon classes) for clarity and consistency. (`packages/core/src/App/Components/Layout/Header/account-info-icon.tsx`

**Component and prop updates:**

* Removed the `is_virtual` prop from `AccountActions`, `AccountInfo`, and related components and tests, simplifying their interfaces and reducing prop redundancy. (`packages/core/src/App/Components/Layout/Header/account-actions.tsx`
* Updated test descriptions and assertions to use "demo" instead of "virtual" for account type checks. 

**Test and mock updates:**

* Adjusted component mocks in tests to remove the `is_virtual` prop and ensure compatibility with the new account type logic. (`packages/core/src/App/Components/Layout/Header/__tests__/account-actions.spec.tsx`