### PR TITLE
Farabi/save-account-type-to-localstorage

### DIFF
--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -2,7 +2,7 @@ import React, { createContext, PropsWithChildren, useCallback, useContext, useEf
 
 // @ts-expect-error `@deriv/deriv-api` is not in TypeScript, Hence we ignore the TS error.
 import DerivAPIBasic from '@deriv/deriv-api/dist/DerivAPIBasic';
-import { getAccountTypeFromUrl, getBrandName, getSocketURL, useWS } from '@deriv/shared';
+import { getAccountType, getBrandName, getSocketURL, useWS } from '@deriv/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import {
@@ -134,7 +134,7 @@ const getEnvironment = () => {
     if (customServerURL) return 'custom';
 
     // Use the new shared account type function
-    return getAccountTypeFromUrl();
+    return getAccountType();
 };
 
 type TAPIProviderProps = {

--- a/packages/core/src/App/Components/Layout/Header/__tests__/account-info.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/account-info.spec.tsx
@@ -1,64 +1,64 @@
 import React from 'react';
 
-import { getAccountTypeFromUrl } from '@deriv/shared';
+import { getAccountType } from '@deriv/shared';
 import { render, screen } from '@testing-library/react';
 
 import AccountInfo from '../account-info.jsx';
 
-// Mock the getAccountTypeFromUrl function
+// Mock the getAccountType function
 jest.mock('@deriv/shared', () => ({
     ...jest.requireActual('@deriv/shared'),
-    getAccountTypeFromUrl: jest.fn(),
+    getAccountType: jest.fn(),
 }));
 
-const mockGetAccountTypeFromUrl = getAccountTypeFromUrl as jest.MockedFunction<typeof getAccountTypeFromUrl>;
+const mockGetAccountType = getAccountType as jest.MockedFunction<typeof getAccountType>;
 
 describe('AccountInfo component', () => {
     beforeEach(() => {
         // Reset the mock before each test
-        mockGetAccountTypeFromUrl.mockReset();
+        mockGetAccountType.mockReset();
     });
 
     it('should have "acc-info--is-demo" class when account_type is "demo"', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        mockGetAccountType.mockReturnValue('demo');
         render(<AccountInfo />);
         const div_element = screen.getByTestId('dt_acc_info');
         expect(div_element).toHaveClass('acc-info--is-demo');
     });
 
     it('should render "AccountInfoIcon" with the proper className', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         const { rerender } = render(<AccountInfo currency='USD' />);
         expect(screen.getByTestId('dt_icon')).toHaveClass('acc-info__id-icon--usd');
 
-        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        mockGetAccountType.mockReturnValue('demo');
         rerender(<AccountInfo />);
         expect(screen.getByTestId('dt_icon')).toHaveClass('acc-info__id-icon--demo');
     });
 
     it('should not render balance section when "currency" property passed', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo currency='USD' />);
         const balance_wrapper = screen.queryByTestId('dt_balance');
         expect(balance_wrapper).not.toBeInTheDocument();
     });
 
     it('should have "acc-info__balance--no-currency" class when account is real and we don\'t have "currency" property', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo />);
         const balance_wrapper = screen.getByTestId('dt_balance');
         expect(balance_wrapper).toHaveClass('acc-info__balance--no-currency');
     });
 
     it('should have "No currency assigned" text when we don\'t have "currency" property', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo />);
         const text = screen.getByText(/no currency assigned/i);
         expect(text).toBeInTheDocument();
     });
 
     it('should have "123456789 USD" text when we have "currency" and "balance" properties', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo currency='USD' balance='123456789' />);
         const text = screen.getByText(/123456789 usd/i);
         expect(text).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe('AccountInfo component', () => {
     });
 
     it('should display "Real" account type label for real accounts', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Real');
         expect(accountTypeLabel).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('AccountInfo component', () => {
     });
 
     it('should display "Demo" account type label for demo accounts', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('demo');
+        mockGetAccountType.mockReturnValue('demo');
         render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Demo');
         expect(accountTypeLabel).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe('AccountInfo component', () => {
     });
 
     it('should display account type label in header section when currency is assigned', () => {
-        mockGetAccountTypeFromUrl.mockReturnValue('real');
+        mockGetAccountType.mockReturnValue('real');
         render(<AccountInfo currency='USD' balance='1000' />);
         const accountTypeLabel = screen.getByText('Real');
         const balanceElement = screen.getByText(/1000 usd/i);

--- a/packages/core/src/App/Components/Layout/Header/account-info.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-info.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { Text } from '@deriv/components';
-import { getAccountTypeFromUrl, getCurrencyDisplayCode } from '@deriv/shared';
+import { getAccountType, getCurrencyDisplayCode } from '@deriv/shared';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { useDevice } from '@deriv-com/ui';
 
@@ -15,9 +15,9 @@ const AccountInfo = ({ balance, currency, is_mobile }) => {
     const currency_lower = currency?.toLowerCase();
     const { isDesktop } = useDevice();
 
-    const accountTypeFromUrl = getAccountTypeFromUrl();
-    const accountTypeHeader = accountTypeFromUrl === 'real' ? localize('Real') : localize('Demo');
-    const isDemoAccount = accountTypeFromUrl === 'demo';
+    const accountType = getAccountType();
+    const accountTypeHeader = accountType === 'real' ? localize('Real') : localize('Demo');
+    const isDemoAccount = accountType === 'demo';
 
     return (
         <div className='acc-info__wrapper'>

--- a/packages/shared/src/utils/config/config.ts
+++ b/packages/shared/src/utils/config/config.ts
@@ -26,17 +26,24 @@ export const isProduction = () => {
 };
 
 /**
- * Parses the account_type parameter from the current URL
+ * Gets account_type with priority: URL parameter > localStorage > default 'demo'
  * @returns {string} 'real', 'demo', or 'demo' as default
  */
-export const getAccountTypeFromUrl = (): string => {
+export const getAccountType = (): string => {
     const search = window.location.search;
     const search_params = new URLSearchParams(search);
-    const accountType = search_params.get('account_type');
+    const accountTypeFromUrl = search_params.get('account_type');
 
-    // Validate account type and return 'demo' as default for invalid values
-    if (accountType === 'real' || accountType === 'demo') {
-        return accountType;
+    // First priority: URL parameter
+    if (accountTypeFromUrl === 'real' || accountTypeFromUrl === 'demo') {
+        window.localStorage.setItem('account_type', accountTypeFromUrl);
+        return accountTypeFromUrl;
+    }
+
+    // Second priority: localStorage
+    const storedAccountType = window.localStorage.getItem('account_type');
+    if (storedAccountType === 'real' || storedAccountType === 'demo') {
+        return storedAccountType;
     }
 
     // Default to demo when no account_type parameter or invalid value
@@ -47,8 +54,8 @@ export const getSocketURL = () => {
     const local_storage_server_url = window.localStorage.getItem('config.server_url');
     if (local_storage_server_url) return local_storage_server_url;
 
-    // Get account type from URL parameter
-    const accountType = getAccountTypeFromUrl();
+    // Get account type
+    const accountType = getAccountType();
 
     // Map account type to new v2 endpoints
     const server_url = accountType === 'real' ? 'realv2.derivws.com' : 'demov2.derivws.com';


### PR DESCRIPTION
This pull request refactors how the account type is determined throughout the codebase by replacing the old `getAccountTypeFromUrl` function with a new, more robust `getAccountType` function. The new function prioritizes the URL parameter, then localStorage, and defaults to 'demo' if neither is set. This change affects shared utilities, core components, API providers, and related tests to ensure consistent account type handling.

**Account type determination improvements:**

* Replaced `getAccountTypeFromUrl` with `getAccountType` in `packages/shared/src/utils/config/config.ts`, updating the logic to check the URL first, then localStorage, and default to 'demo'. The function now also sets localStorage if the URL parameter is present.
* Updated the socket URL logic in `getSocketURL` to use the new `getAccountType` function for mapping to the correct server endpoint.

**Codebase-wide refactoring:**

* Refactored imports and usage from `getAccountTypeFromUrl` to `getAccountType` in `APIProvider.tsx`, `account-info.jsx`, and all related test files to use the new function. 
* Updated account info display logic in `account-info.jsx` to use the new account type determination method, ensuring correct labels and UI states.

**Test updates:**

* Modified mocks and references in account info tests to use `getAccountType` instead of the deprecated function, ensuring tests reflect the new logic.

These changes collectively improve reliability and consistency in how the application determines and uses the account type across different environments and user sessions.