### PR TITLE
Farabi/grwt-7102/sync-user-with-different-tabs

### DIFF
--- a/packages/trader/src/AppV2/Hooks/useTokenSync.ts
+++ b/packages/trader/src/AppV2/Hooks/useTokenSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Custom hook to sync localStorage changes across tabs
@@ -11,13 +11,10 @@ import { useEffect, useRef } from 'react';
  * - When another tab changes the session_token, this tab will automatically refresh
  *
  * Usage:
- * - Import and call this hook in your AuthProvider or main App component
+ * - Import and call this hook in your main App component
  * - When another tab changes the session_token, this tab will automatically refresh
- * - Changes made by the current tab will not trigger a refresh
  */
 export const useTokenSync = () => {
-    const isOwnChange = useRef(false);
-
     useEffect(() => {
         const handleStorageChange = (event: StorageEvent) => {
             // Only handle session_token changes
@@ -38,46 +35,4 @@ export const useTokenSync = () => {
             window.removeEventListener('storage', handleStorageChange);
         };
     }, []);
-
-    /**
-     * Wrapper function to set session_token in localStorage
-     * This prevents the storage event from firing on the current tab
-     *
-     * @param token - The session token to store
-     */
-    const setSessionToken = (token: string) => {
-        isOwnChange.current = true;
-        localStorage.setItem('session_token', token);
-
-        // Reset the flag after a short delay
-        setTimeout(() => {
-            isOwnChange.current = false;
-        }, 50);
-    };
-
-    /**
-     * Wrapper function to remove session_token from localStorage
-     */
-    const removeSessionToken = () => {
-        isOwnChange.current = true;
-        localStorage.removeItem('session_token');
-
-        // Reset the flag after a short delay
-        setTimeout(() => {
-            isOwnChange.current = false;
-        }, 50);
-    };
-
-    /**
-     * Get the current session token from localStorage
-     */
-    const getSessionToken = () => {
-        return localStorage.getItem('session_token');
-    };
-
-    return {
-        setSessionToken,
-        removeSessionToken,
-        getSessionToken,
-    };
 };

--- a/packages/trader/src/AppV2/Hooks/useTokenSync.ts
+++ b/packages/trader/src/AppV2/Hooks/useTokenSync.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Custom hook to sync localStorage changes across tabs
+ * Specifically monitors 'session_token' changes from other tabs and refreshes the page
+ *
+ * How it works:
+ * - The 'storage' event only fires on other tabs/windows when localStorage is modified
+ * - It does NOT fire on the tab that made the change
+ * - This is perfect for detecting session token changes from other tabs
+ * - When another tab changes the session_token, this tab will automatically refresh
+ *
+ * Usage:
+ * - Import and call this hook in your AuthProvider or main App component
+ * - When another tab changes the session_token, this tab will automatically refresh
+ * - Changes made by the current tab will not trigger a refresh
+ */
+export const useTokenSync = () => {
+    const isOwnChange = useRef(false);
+
+    useEffect(() => {
+        const handleStorageChange = (event: StorageEvent) => {
+            // Only handle session_token changes
+            if (event.key !== 'session_token') {
+                return;
+            }
+
+            // Add a small delay to ensure localStorage is fully updated
+            setTimeout(() => {
+                window.location.reload();
+            }, 100);
+        };
+
+        // Listen for localStorage changes from other tabs
+        window.addEventListener('storage', handleStorageChange);
+
+        return () => {
+            window.removeEventListener('storage', handleStorageChange);
+        };
+    }, []);
+
+    /**
+     * Wrapper function to set session_token in localStorage
+     * This prevents the storage event from firing on the current tab
+     *
+     * @param token - The session token to store
+     */
+    const setSessionToken = (token: string) => {
+        isOwnChange.current = true;
+        localStorage.setItem('session_token', token);
+
+        // Reset the flag after a short delay
+        setTimeout(() => {
+            isOwnChange.current = false;
+        }, 50);
+    };
+
+    /**
+     * Wrapper function to remove session_token from localStorage
+     */
+    const removeSessionToken = () => {
+        isOwnChange.current = true;
+        localStorage.removeItem('session_token');
+
+        // Reset the flag after a short delay
+        setTimeout(() => {
+            isOwnChange.current = false;
+        }, 50);
+    };
+
+    /**
+     * Get the current session token from localStorage
+     */
+    const getSessionToken = () => {
+        return localStorage.getItem('session_token');
+    };
+
+    return {
+        setSessionToken,
+        removeSessionToken,
+        getSessionToken,
+    };
+};

--- a/packages/trader/src/AppV2/app.tsx
+++ b/packages/trader/src/AppV2/app.tsx
@@ -14,6 +14,7 @@ import TraderProviders from '../trader-providers';
 
 import ServicesErrorSnackbar from './Components/ServicesErrorSnackbar';
 import Notifications from './Containers/Notifications';
+import { useTokenSync } from './Hooks/useTokenSync';
 import Router from './Routes/router';
 
 import 'Sass/app.scss';
@@ -27,6 +28,9 @@ type Apptypes = {
 
 const App = ({ passthrough }: Apptypes) => {
     const root_store = initStore(passthrough.root_store, passthrough.WS);
+
+    // Initialize token sync hook to handle session token changes across tabs
+    useTokenSync();
 
     React.useEffect(() => {
         return () => root_store.ui.setPromptHandler(false);


### PR DESCRIPTION
This pull request introduces a new custom hook to synchronize session token changes across browser tabs in the Trader app. The hook ensures that when the `session_token` is updated in one tab, other tabs detect the change and automatically refresh, maintaining consistent authentication state. The hook is initialized in the main app component for seamless integration.

**Session token synchronization improvements:**

* Added a new `useTokenSync` custom hook in `useTokenSync.ts` to listen for `session_token` changes in localStorage from other tabs and refresh the page when detected. The hook also provides helper functions to set, remove, and get the session token.
* Imported and initialized the `useTokenSync` hook in the main app component (`app.tsx`) to enable cross-tab session token synchronization.